### PR TITLE
using the lock uuid id as the key fro the locks in the lock factory

### DIFF
--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -19,15 +19,14 @@ func NewControllersServer() *ControllersServer {
 		),
 	}
 
-	resourceServices := env().Services.Resources()
 	sourceClient := env().Clients.CloudEventsSource
 
 	s.KindControllerManager.Add(&controllers.ControllerConfig{
 		Source: "Resources",
 		Handlers: map[api.EventType][]controllers.ControllerHandlerFunc{
-			api.CreateEventType: {resourceServices.OnUpsert, sourceClient.OnCreate},
-			api.UpdateEventType: {resourceServices.OnUpsert, sourceClient.OnUpdate},
-			api.DeleteEventType: {resourceServices.OnDelete, sourceClient.OnDelete},
+			api.CreateEventType: {sourceClient.OnCreate},
+			api.UpdateEventType: {sourceClient.OnUpdate},
+			api.DeleteEventType: {sourceClient.OnDelete},
 		},
 	})
 

--- a/pkg/db/advisory_locks.go
+++ b/pkg/db/advisory_locks.go
@@ -18,9 +18,10 @@ type (
 )
 
 const (
-	Migrations LockType = "migrations"
-	Resources  LockType = "Resources"
-	Events     LockType = "events"
+	Migrations     LockType = "migrations"
+	Resources      LockType = "Resources"
+	ResourceStatus LockType = "ResourceStatus"
+	Events         LockType = "events"
 )
 
 // LockFactory provides the blocking/unblocking locks based on PostgreSQL advisory lock.
@@ -59,15 +60,15 @@ func (f *AdvisoryLockFactory) NewAdvisoryLock(ctx context.Context, id string, lo
 	// obtain the advisory lock (blocking)
 	if err := lock.lock(); err != nil {
 		UpdateAdvisoryLockCountMetric(lockType, "lock error")
-		errMsg := fmt.Sprintf("error obtaining the advisory lock for id %s with (%d, %d), %v",
-			id, hash(*lock.id), hash(string(*lock.lockType)), err)
+		errMsg := fmt.Sprintf("error obtaining the advisory lock for id %s type %s, %v", id, lockType, err)
 		log.Error(errMsg)
 		// the lock transaction is already started, if error happens, we return the transaction id, so that the caller
 		// can end this transaction.
 		return *lock.uuid, fmt.Errorf(errMsg)
 	}
 
-	f.locks[fmt.Sprintf("%s-%s", id, lockType)] = lock
+	log.V(4).Info(fmt.Sprintf("Locked advisory lock id=%s type=%s - owner=%s", id, lockType, *lock.uuid))
+	f.locks[*lock.uuid] = lock
 	return *lock.uuid, nil
 }
 
@@ -83,15 +84,15 @@ func (f *AdvisoryLockFactory) NewNonBlockingLock(ctx context.Context, id string,
 	acquired, err := lock.nonBlockingLock()
 	if err != nil {
 		UpdateAdvisoryLockCountMetric(lockType, "lock error")
-		errMsg := fmt.Sprintf("error obtaining the non blocking advisory lock for id %s with (%d, %d), %v",
-			id, hash(*lock.id), hash(string(*lock.lockType)), err)
+		errMsg := fmt.Sprintf("error obtaining the non blocking advisory lock for id %s type %s, %v", id, lockType, err)
 		log.Error(errMsg)
 		// the lock transaction is already started, if error happens, we return the transaction id, so that the caller
 		// can end this transaction.
 		return *lock.uuid, false, fmt.Errorf(errMsg)
 	}
 
-	f.locks[fmt.Sprintf("%s-%s", id, lockType)] = lock
+	log.V(4).Info(fmt.Sprintf("Locked non blocking advisory lock id=%s type=%s - owner=%s", id, lockType, *lock.uuid))
+	f.locks[*lock.uuid] = lock
 	return *lock.uuid, acquired, nil
 }
 
@@ -116,41 +117,36 @@ func (f *AdvisoryLockFactory) newLock(ctx context.Context, id string, lockType L
 func (f *AdvisoryLockFactory) Unlock(ctx context.Context, uuid string) {
 	log := logger.NewOCMLogger(ctx)
 
-	for k, lock := range f.locks {
-		if lock.uuid == nil {
-			log.Error("lockOwnerID could not be found in AdvisoryLock")
-			continue
-		}
-
-		if *lock.uuid != uuid {
-			continue
-		}
-
-		lockType := *lock.lockType
-		lockID := "<missing>"
-		if lock.id != nil {
-			lockID = *lock.id
-		}
-
-		if err := lock.unlock(); err != nil {
-			UpdateAdvisoryLockCountMetric(lockType, "unlock error")
-			log.Extra("lockID", lockID).Extra("owner", uuid).Error(fmt.Sprintf("Could not unlock, %v", err))
-		}
-
-		UpdateAdvisoryLockCountMetric(lockType, "OK")
-		UpdateAdvisoryLockDurationMetric(lockType, "OK", lock.startTime)
-
-		log.Info(fmt.Sprintf("Unlocked lock id=%s - owner=%s", lockID, uuid))
-
-		delete(f.locks, k)
+	if uuid == "" {
 		return
 	}
 
-	// the resolving UUID belongs to a service call that did *not* initiate the lock.
-	// we can safely ignore this, knowing the top-most func in the call stack
-	// will provide the correct UUID.
-	// This will happen frequently as many pkg/service functions participate in locks.
-	log.Info(fmt.Sprintf("Caller not lock owner. Owner %s", uuid))
+	lock, ok := f.locks[uuid]
+	if !ok {
+		// the resolving UUID belongs to a service call that did *not* initiate the lock.
+		// we can safely ignore this, knowing the top-most func in the call stack
+		// will provide the correct UUID.
+		log.V(4).Info(fmt.Sprintf("Caller not lock owner. Owner %s", uuid))
+		return
+	}
+
+	lockType := *lock.lockType
+	lockID := "<missing>"
+	if lock.id != nil {
+		lockID = *lock.id
+	}
+
+	if err := lock.unlock(); err != nil {
+		UpdateAdvisoryLockCountMetric(lockType, "unlock error")
+		log.Extra("lockID", lockID).Extra("owner", uuid).Error(fmt.Sprintf("Could not unlock, %v", err))
+	}
+
+	UpdateAdvisoryLockCountMetric(lockType, "OK")
+	UpdateAdvisoryLockDurationMetric(lockType, "OK", lock.startTime)
+
+	log.V(4).Info(fmt.Sprintf("Unlocked lock id=%s type=%s - owner=%s", lockID, lockType, uuid))
+
+	delete(f.locks, uuid)
 }
 
 // AdvisoryLock represents a postgres advisory lock

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -378,4 +378,18 @@ func TestUpdateResourceWithRacingRequests(t *testing.T) {
 
 	// the resource patch request is protected by the advisory lock, so there should only be one update
 	Expect(updatedCount).To(Equal(1))
+
+	// all the locks should be released finally
+	Eventually(func() error {
+		var count int
+		err := h.DBFactory.DirectDB().
+			QueryRow("select count(*) from pg_locks where locktype='advisory';").
+			Scan(&count)
+		Expect(err).NotTo(HaveOccurred(), "Error querying pg_locks:  %v", err)
+
+		if count != 0 {
+			return fmt.Errorf("there are %d unreleased advisory lock", count)
+		}
+		return nil
+	}, 5*time.Second, 1*time.Second).Should(Succeed())
 }


### PR DESCRIPTION
To fix the bug when using multiple processes to update a resource at a same time, the advisory lock cannot be released,
e.g.

```
I1215 10:46:14.753168       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1b0f820a-66bb-41a3-909a-6fbcad27a808
I1215 10:46:14.760572       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1b0f820a-66bb-41a3-909a-6fbcad27a808
I1215 10:46:14.760936       1 logger.go:129]   Unlocked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1b0f820a-66bb-41a3-909a-6fbcad27a808
I1215 10:46:14.773887       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=bdcc1f7d-d3c8-43a8-8855-1b9a596ad1d1
I1215 10:46:14.774434       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=bdcc1f7d-d3c8-43a8-8855-1b9a596ad1d1
I1215 10:46:14.774627       1 logger.go:129]   Unlocked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=bdcc1f7d-d3c8-43a8-8855-1b9a596ad1d1
I1215 10:46:14.782346       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=9c75bf8c-03b0-4e65-8d0d-2736f44c6ab9
I1215 10:46:14.783494       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=9c75bf8c-03b0-4e65-8d0d-2736f44c6ab9
I1215 10:46:14.783721       1 logger.go:129]   Unlocked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=9c75bf8c-03b0-4e65-8d0d-2736f44c6ab9
I1215 10:46:14.789584       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1754cabe-1d2a-464f-937f-0a96e129574f
I1215 10:46:14.801023       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1754cabe-1d2a-464f-937f-0a96e129574f
I1215 10:46:14.801875       1 logger.go:129]   Unlocked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=1754cabe-1d2a-464f-937f-0a96e129574f
I1215 10:46:14.807207       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=7e3ef587-0020-478d-86d3-f668deca0d3c
I1215 10:46:14.811219       1 logger.go:129]   UpdateStatusDone lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=7e3ef587-0020-478d-86d3-f668deca0d3c
I1215 10:46:14.811250       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=7e3ef587-0020-478d-86d3-f668deca0d3c
I1215 10:46:14.811427       1 logger.go:129]   Locked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=eef61c92-983a-4037-8dc8-70bebf9e45ae
I1215 10:46:14.811482       1 logger.go:129]   Unlocked lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=7e3ef587-0020-478d-86d3-f668deca0d3c
I1215 10:46:14.811934       1 logger.go:129]   UpdateStatusDefer lock id=cd99e9c8-02db-415c-a0dd-4c5ba9f1ea14 type=ResourceStatus - owner=eef61c92-983a-4037-8dc8-70bebf9e45ae
Caller not lock owner. Owner eef61c92-983a-4037-8dc8-70bebf9e45ae
```

for the resource `cd99e9c8-02db-415c...`, it has multiple owners, if we use lockID and the locktype as the key, in some case, this lock will be released previously