### PR TITLE
fix maestro agent klog flags.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
 	k8s.io/component-base v0.28.2
+	k8s.io/klog/v2 v2.100.1
 	open-cluster-management.io/api v0.12.1-0.20240103082609-f6404f30c42c
 	open-cluster-management.io/ocm v0.12.1-0.20231208025610-2e07fda72f59
 )
@@ -142,7 +143,6 @@ require (
 	k8s.io/api v0.28.2 // indirect
 	k8s.io/apiextensions-apiserver v0.28.1 // indirect
 	k8s.io/apiserver v0.28.1 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kms v0.28.1 // indirect
 	k8s.io/kube-aggregator v0.28.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect


### PR DESCRIPTION
This pull request addresses the issue where agent klog flags are not functioning correctly due to conflicting definitions with glog(server) and klog in Maestro. The problem arises when both are used simultaneously, leading to the redefinition of flags and rendering agent flags ineffective. To resolve this, the PR introduces klog flags to the agent subcommand and implements a check to prevent redefinition before adding them to the flag set.

Now we can set `-v=5` to maestro agent:

```bash
...
I0111 03:36:58.747559       1 baseclient.go:120] Sent event: context.TODO
Context Attributes,
  specversion: 1.0
  type: io.open-cluster-management.works.v1alpha1.manifests.spec.resync_request
  source: b8da4ca7-052a-4322-8e12-5e38e82c5fce-work-agent
  id: bc1afd0e-d089-4d52-ba15-a03d78bff219
  time: 2024-01-11T03:36:58.74748891Z
  datacontenttype: application/json
Extensions,
  clustername: b8da4ca7-052a-4322-8e12-5e38e82c5fce
Data,
  {
    "resourceVersions": []
  }
  ...
```

/cc @clyang82 @skeeey 