### PR TITLE
fix controller manager context.

### DIFF
--- a/cmd/maestro/servecmd/cmd.go
+++ b/cmd/maestro/servecmd/cmd.go
@@ -65,7 +65,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	go apiserver.Start()
 	go metricsServer.Start()
 	go healthcheckServer.Start()
-	go controllersServer.Start(ctx.Done())
+	go controllersServer.Start(ctx)
 
 	<-ctx.Done()
 }

--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -39,13 +39,13 @@ type ControllersServer struct {
 }
 
 // Start is a blocking call that starts this controller server
-func (s ControllersServer) Start(stopCh <-chan struct{}) {
+func (s ControllersServer) Start(ctx context.Context) {
 	log := logger.NewOCMLogger(context.Background())
 
 	log.Infof("Kind controller handling events")
-	go s.KindControllerManager.Run(stopCh)
+	go s.KindControllerManager.Run(ctx.Done())
 
 	log.Infof("Kind controller listening for events")
 	// blocking call
-	env().Database.SessionFactory.NewListener(context.Background(), "events", s.KindControllerManager.AddEvent)
+	env().Database.SessionFactory.NewListener(ctx, "events", s.KindControllerManager.AddEvent)
 }

--- a/test/helper.go
+++ b/test/helper.go
@@ -198,7 +198,7 @@ func (helper *Helper) StartControllerManager(ctx context.Context) {
 	})
 
 	// start controller manager
-	go helper.ControllerManager.Start(ctx.Done())
+	go helper.ControllerManager.Start(ctx)
 }
 
 func (helper *Helper) StartWorkAgent(ctx context.Context, clusterName string, mqttOptions *mqttoptions.MQTTOptions) {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -69,7 +69,7 @@ func TestControllerRacing(t *testing.T) {
 				},
 			})
 
-			s.Start(ctx.Done())
+			s.Start(ctx)
 		}()
 	}
 
@@ -126,7 +126,7 @@ func TestControllerReconcile(t *testing.T) {
 			},
 		})
 
-		s.Start(ctx.Done())
+		s.Start(ctx)
 	}()
 
 	consumer := h.NewConsumer("cluster1")
@@ -219,7 +219,7 @@ func TestControllerSync(t *testing.T) {
 			},
 		})
 
-		s.Start(ctx.Done())
+		s.Start(ctx)
 	}()
 
 	// Eventually, the controller should only handle the one unreconciled event.


### PR DESCRIPTION
Currently the DB listener is created with new context, instead of parent context: https://github.com/openshift-online/maestro/blob/d279533ff13934767606e702b9cf843c04bea0dc/cmd/maestro/server/controllers.go#L42-L51

This will results that in some case, the controller manager is done (should close DB/reset DB in integration test), but the DB listener is still try to connect to database, then there will be a nil pointer error, see:

```bash
FAIL test/integration
=== RUN   TestResourcePost
I0118 07:53:44.646368  219378 helper.go:196] ============ start controller manager ============
{"level":"info","ts":1705564424.6480644,"logger":"fallback","caller":"v2@v2.0.0-20231030012137-0836a524e995/protocol.go:124","msg":"subscribing to topics: map[sources/+/clusters/76d67758-00e6-4dd7-b043-7164c8626810/spec:{1 0 false false} sources/+/clusters/statusresync:{1 0 false false}]"}
I0118 07:53:44.649750  219378 authz_middleware_mock.go:18] Mock authz allows <any>/<any> for "POST"/"/api/maestro/v1/resources"
I0118 07:53:44.688750  219378 authz_middleware_mock.go:18] Mock authz allows <any>/<any> for "POST"/"/api/maestro/v1/resources"
E0118 07:53:44.692873  219378 logger.go:129]   Failed to handle the event 1df1f4ed-48e9-4349-acde-439d7afc5026, <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x18d17cf]

goroutine 210 [running]:
github.com/openshift-online/maestro/pkg/db/db_session.waitForNotification({0x2485240, 0x3785320}, 0xc0001542a0, 0xc0003360b0)
	/root/workspace/openshift-online-maestro/pkg/db/db_session/default.go:108 +0x12f
github.com/openshift-online/maestro/pkg/db/db_session.newListener({0x2485240, 0x3785320}, {0xc0006ec080, 0x80}, {0x212dba9, 0x6}, 0x1e78ac0?)
	/root/workspace/openshift-online-maestro/pkg/db/db_session/default.go:134 +0x1de
github.com/openshift-online/maestro/pkg/db/db_session.(*Test).NewListener(0xc0001fac30?, {0x2485240, 0x3785320}, {0x212dba9, 0x6}, 0x419132?)
	/root/workspace/openshift-online-maestro/pkg/db/db_session/test.go:221 +0x69
github.com/openshift-online/maestro/cmd/maestro/server.ControllersServer.Start({0xc000902340?, {0x0?, 0x0?}}, 0xc000888120)
	/root/workspace/openshift-online-maestro/cmd/maestro/server/controllers.go:50 +0x169
github.com/openshift-online/maestro/test/integration.TestControllerRacing.func2()
	/root/workspace/openshift-online-maestro/test/integration/controller_test.go:72 +0x59e
created by github.com/openshift-online/maestro/test/integration.TestControllerRacing in goroutine 173
	/root/workspace/openshift-online-maestro/test/integration/controller_test.go:56 +0x125
FAIL test/integration.TestResourcePost (-1.00s)
```