### PR TITLE
graceful shutdown db connection for pulse server.

### DIFF
--- a/pkg/db/db_session/default.go
+++ b/pkg/db/db_session/default.go
@@ -105,8 +105,10 @@ func waitForNotification(ctx context.Context, l *pq.Listener, callback func(id s
 			logger.Infof("Context cancelled, stopping channel monitor")
 			return
 		case n := <-l.Notify:
-			logger.Infof("Received data from channel [%s] : %s", n.Channel, n.Extra)
-			callback(n.Extra)
+			if n != nil {
+				logger.Infof("Received data from channel [%s] : %s", n.Channel, n.Extra)
+				callback(n.Extra)
+			}
 		case <-time.After(10 * time.Second):
 			logger.V(10).Infof("Received no events on channel during interval. Pinging source")
 			go func() {

--- a/pkg/dispatcher/hash_dispatcher.go
+++ b/pkg/dispatcher/hash_dispatcher.go
@@ -55,7 +55,7 @@ func (d *HashDispatcher) Start(ctx context.Context) {
 	go d.startStatusResyncWorkers(ctx)
 
 	// start a goroutine to periodically check the instances and consumers.
-	go wait.Until(d.check, 5*time.Second, ctx.Done())
+	go wait.UntilWithContext(ctx, d.check, 5*time.Second)
 
 	// wait until context is canceled
 	<-ctx.Done()
@@ -170,8 +170,7 @@ func (d *HashDispatcher) startStatusResyncWorkers(ctx context.Context) {
 }
 
 // check checks the instances & consumers and updates the hashing ring and consumer set for the current instance.
-func (d *HashDispatcher) check() {
-	ctx := context.TODO()
+func (d *HashDispatcher) check(ctx context.Context) {
 	log := logger.NewOCMLogger(ctx)
 
 	instances, err := d.instanceDao.All(ctx)

--- a/test/helper.go
+++ b/test/helper.go
@@ -116,6 +116,7 @@ func NewHelper(t *testing.T) *Helper {
 		helper.startAPIServer()
 		helper.startMetricsServer()
 		helper.startHealthCheckServer()
+		helper.startPulseServer(helper.Ctx)
 	})
 	helper.T = t
 	return helper
@@ -180,12 +181,12 @@ func (helper *Helper) startHealthCheckServer() {
 	}()
 }
 
-func (helper *Helper) StartPulseServer(ctx context.Context) {
+func (helper *Helper) startPulseServer(ctx context.Context) {
 	helper.Env().Config.PulseServer.PulseInterval = 1
-	helper.PulseServer = server.NewPulseServer()
+	helper.Env().Config.PulseServer.SubscriptionType = "broadcast"
 	go func() {
 		glog.V(10).Info("Test pulse server started")
-		helper.PulseServer.Start(ctx)
+		server.NewPulseServer().Start(ctx)
 		glog.V(10).Info("Test pulse server stopped")
 	}()
 }


### PR DESCRIPTION
This PR tries to add graceful shutdown of db connection for pulse server.

test results:

```bash
# make test-integration
CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -ldflags="" ./cmd/maestro
OCM_ENV=testing gotestsum --format short-verbose -- -p 1 -ldflags -s -v -timeout 1h  \
		./test/integration
I0204 04:22:03.284289  170814 framework.go:76] Initializing testing environment
I0204 04:22:03.510700  170814 framework.go:161] Using Mock OCM Authz Client
I0204 04:22:03.512101  170814 framework.go:199] Disabling Sentry error reporting
I0204 04:22:03.522273  170814 api_server.go:145] Serving without TLS at localhost:8000
I0204 04:22:03.522471  170814 healthcheck_server.go:56] Serving HealthCheck without TLS at localhost:8083
PASS test/integration.TestConsumerGet (0.30s)
PASS test/integration.TestConsumerPost (0.20s)
PASS test/integration.TestConsumerPaging (0.22s)
PASS test/integration.TestControllerRacing (1.61s)
PASS test/integration.TestControllerReconcile (1.20s)
PASS test/integration.TestControllerSync (1.19s)
PASS test/integration.TestPulseServer (6.23s)
PASS test/integration.TestResourceGet (0.32s)
PASS test/integration.TestResourcePost (4.32s)
PASS test/integration.TestResourcePatch (0.36s)
PASS test/integration.TestResourcePaging (0.30s)
PASS test/integration.TestResourceListSearch (0.32s)
PASS test/integration.TestUpdateResourceWithRacingRequests (0.43s)
E0204 04:22:20.540065  170814 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0204 04:22:20.541411  170814 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0204 04:22:20.542563  170814 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0204 04:22:20.543822  170814 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
I0204 04:22:20.544523  170814 api_server.go:151] Web server terminated
PASS test/integration (cached)

DONE 13 tests in 1.065s
```