### PR TITLE
resource status conversion.

### DIFF
--- a/pkg/client/cloudevents/source_client_mock.go
+++ b/pkg/client/cloudevents/source_client_mock.go
@@ -2,7 +2,6 @@ package cloudevents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/bwmarrin/snowflake"
@@ -59,13 +58,10 @@ func (s *SourceClientMock) OnCreate(ctx context.Context, id string) error {
 		},
 	}
 
-	resourceStatusJSON, err := json.Marshal(resourceStatus)
+	var err error
+	resource.Status, err = api.ResourceStatusToJSONMap(resourceStatus)
 	if err != nil {
-		return fmt.Errorf("failed to marshal resource status: %v", err)
-	}
-	err = json.Unmarshal(resourceStatusJSON, &resource.Status)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal resource status: %v", err)
+		return fmt.Errorf("failed to convert resource status: %v", err)
 	}
 
 	newResource, serviceErr := s.ResourceService.UpdateStatus(ctx, resource)
@@ -87,13 +83,9 @@ func (s *SourceClientMock) OnUpdate(ctx context.Context, id string) error {
 	found := false
 	for i, r := range s.resources {
 		if r.ID == resource.ID {
-			resourceStatusJSON, err := json.Marshal(resource.Status)
+			resourceStatus, err := api.JSONMapStatusToResourceStatus(resource.Status)
 			if err != nil {
-				return fmt.Errorf("failed to marshal resource status: %v", err)
-			}
-			resourceStatus := &api.ResourceStatus{}
-			if err := json.Unmarshal(resourceStatusJSON, resourceStatus); err != nil {
-				return fmt.Errorf("failed to unmarshal resource status: %v", err)
+				return fmt.Errorf("failed to convert resource status: %v", err)
 			}
 			if resourceStatus.ReconcileStatus == nil {
 				resourceStatus.ReconcileStatus = &api.ReconcileStatus{}
@@ -110,13 +102,9 @@ func (s *SourceClientMock) OnUpdate(ctx context.Context, id string) error {
 			}
 
 			resourceStatus.ReconcileStatus.Conditions = append(resourceStatus.ReconcileStatus.Conditions, condition)
-			resourceStatusJSON, err = json.Marshal(resourceStatus)
+			resource.Status, err = api.ResourceStatusToJSONMap(resourceStatus)
 			if err != nil {
-				return fmt.Errorf("failed to marshal resource status: %v", err)
-			}
-			err = json.Unmarshal(resourceStatusJSON, &resource.Status)
-			if err != nil {
-				return fmt.Errorf("failed to unmarshal resource status: %v", err)
+				return fmt.Errorf("failed to convert resource status: %v", err)
 			}
 
 			newResource, serviceErr := s.ResourceService.UpdateStatus(ctx, resource)


### PR DESCRIPTION
This PR reuses marshal/unmarshal function from api to convert resource status.

```bash
$ make test-integration
CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -ldflags="" ./cmd/maestro
OCM_ENV=testing gotestsum --format short-verbose -- -p 1 -ldflags -s -v -timeout 1h  \
		./test/integration
I0205 02:51:21.504591   20534 framework.go:76] Initializing testing environment
I0205 02:51:21.717476   20534 framework.go:161] Using Mock OCM Authz Client
I0205 02:51:21.720223   20534 framework.go:199] Disabling Sentry error reporting
I0205 02:51:21.728717   20534 api_server.go:145] Serving without TLS at localhost:8000
I0205 02:51:21.728836   20534 healthcheck_server.go:56] Serving HealthCheck without TLS at localhost:8083
PASS test/integration.TestConsumerGet (0.20s)
PASS test/integration.TestConsumerPost (0.27s)
PASS test/integration.TestConsumerPaging (0.23s)
PASS test/integration.TestControllerRacing (1.52s)
PASS test/integration.TestControllerReconcile (1.28s)
PASS test/integration.TestControllerSync (1.18s)
PASS test/integration.TestPulseServer (6.18s)
PASS test/integration.TestResourceGet (0.28s)
PASS test/integration.TestResourcePost (4.31s)
PASS test/integration.TestResourcePatch (0.22s)
PASS test/integration.TestResourcePaging (0.36s)
PASS test/integration.TestResourceListSearch (0.28s)
PASS test/integration.TestUpdateResourceWithRacingRequests (0.41s)
E0205 02:51:38.478249   20534 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0205 02:51:38.479373   20534 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0205 02:51:38.480199   20534 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0205 02:51:38.481091   20534 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
E0205 02:51:38.482036   20534 logger.go:129]   Unable to get all maestro instances: pq: relation "server_instances" does not exist
I0205 02:51:38.482110   20534 api_server.go:151] Web server terminated
PASS test/integration

DONE 13 tests in 21.975s
```