### PR TITLE
supprt grpc subscription.

### DIFF
--- a/cmd/maestro/servecmd/cmd.go
+++ b/cmd/maestro/servecmd/cmd.go
@@ -35,14 +35,14 @@ func runServer(cmd *cobra.Command, args []string) {
 		glog.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
 
-	// Create event hub to broadcast resource status update events to subscribers
-	eventHub := event.NewEventHub()
+	// Create event broadcaster to broadcast resource status update events to subscribers
+	eventBroadcaster := event.NewEventBroadcaster()
 
 	// Create the servers
-	apiserver := server.NewAPIServer(eventHub)
+	apiserver := server.NewAPIServer(eventBroadcaster)
 	metricsServer := server.NewMetricsServer()
 	healthcheckServer := server.NewHealthCheckServer()
-	pulseServer := server.NewPulseServer(eventHub)
+	pulseServer := server.NewPulseServer(eventBroadcaster)
 	controllersServer := server.NewControllersServer()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -66,8 +66,8 @@ func runServer(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	// Start the event hub
-	go eventHub.Start(ctx)
+	// Start the event broadcaster
+	go eventBroadcaster.Start(ctx)
 
 	// Run the servers
 	go apiserver.Start()

--- a/cmd/maestro/server/api_server.go
+++ b/cmd/maestro/server/api_server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-online/maestro/cmd/maestro/environments"
 	"github.com/openshift-online/maestro/data/generated/openapi"
 	"github.com/openshift-online/maestro/pkg/errors"
+	"github.com/openshift-online/maestro/pkg/event"
 )
 
 type apiServer struct {
@@ -32,7 +33,7 @@ func env() *environments.Env {
 	return environments.Environment()
 }
 
-func NewAPIServer() Server {
+func NewAPIServer(eventHub *event.EventHub) Server {
 	s := &apiServer{}
 
 	mainRouter := s.routes()
@@ -125,7 +126,7 @@ func NewAPIServer() Server {
 
 	// TODO: support authn and authz for gRPC
 	if env().Config.GRPCServer.EnableGRPCServer {
-		s.grpcServer = NewGRPCServer(env().Services.Resources(), *env().Config.GRPCServer)
+		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventHub, *env().Config.GRPCServer)
 	}
 	return s
 }

--- a/cmd/maestro/server/api_server.go
+++ b/cmd/maestro/server/api_server.go
@@ -33,7 +33,7 @@ func env() *environments.Env {
 	return environments.Environment()
 }
 
-func NewAPIServer(eventHub *event.EventHub) Server {
+func NewAPIServer(eventBroadcaster *event.EventBroadcaster) Server {
 	s := &apiServer{}
 
 	mainRouter := s.routes()
@@ -126,7 +126,7 @@ func NewAPIServer(eventHub *event.EventHub) Server {
 
 	// TODO: support authn and authz for gRPC
 	if env().Config.GRPCServer.EnableGRPCServer {
-		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventHub, *env().Config.GRPCServer)
+		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventBroadcaster, *env().Config.GRPCServer)
 	}
 	return s
 }

--- a/docs/grpc.md
+++ b/docs/grpc.md
@@ -1,35 +1,66 @@
-## gRPC server
+# gRPC server
+
 gPRC server is disabled by default. You can enable it by passing `--enable-grpc-server=true` to the maestro server start command.
 
-### How to use gRPC server
-You need to initialize the gRPC client with the server address and port. You can use the `grpcoptions` package to initialize the gRPC client. 
+## How to Use
 
-Before initializing the client, you need to define the resource codec. The resource codec is used to encode and decode the resource. The resource codec should implement the `ResourceCodec` interface. The `ResourceCodec` interface has two methods: `Encode` and `Decode`. The `Encode` method is used to encode the resource to the cloudevents, and the `Decode` method is used to decode the cloudevents to the resource. Refer to the `test/grpc_codec.go` for the example of the resource codec.
+### Initliaze the gRPC source client
 
-Once the resource codec is defined, you can initialize the gRPC client using the `grpcoptions` package. The `grpcoptions` package has the `NewGRPCOptions` method to initialize the gRPC options. The `NewGRPCOptions` method takes the server address and port as the input and returns the gRPC options. The gRPC options are used to initialize the gRPC client. The `grpcoptions` package also has the `NewSourceOptions` method to initialize the source options. The `NewSourceOptions` method takes the gRPC options and the source name as the input and returns the source options. The source options are used to initialize the source client. The source client is used to publish the cloudevents:
-```
+1. Initialize the gRPC source client by employing the [grpc package](https://pkg.go.dev/open-cluster-management.io/sdk-go@v0.13.0/pkg/cloudevents/generic/options/grpc).
+
+    - Set up the gRPC options, including the gRPC server URL, SSL configuration, and other relevant parameters.
+    - Initialize the gRPC source options by utilizing the previously configured gRPC options and specifying the source ID.
+
+    ```golang
     import grpcoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
-	...
-    grpcOptions := grpcoptions.NewGRPCOptions()
-	grpcOptions.URL = h.Env().Config.GRPCServer.BindAddress
-	grpcSourceCloudEventsClient, err := generic.NewCloudEventSourceClient[*api.Resource](
-		ctx,
-		grpcoptions.NewSourceOptions(grpcOptions, "grpc-example"),
-		nil,
-		nil,
-		&ResourceCodec{},
-	)
-```
-Once the client is initialized, you can use it to publish the cloudevents:
-```
+
+    grpcOptions = grpcoptions.NewGRPCOptions()
+    grpcOptions.URL = h.Env().Config.GRPCServer.BindAddress
+    grpcSourceOption = grpcoptions.NewSourceOptions(grpcOptions, "grpc-source-example")
+    ```
+
+2. Define the resource codec responsible for encoding and decoding the resource. Ensure that the resource codec adheres to the [generic.Codec](https://pkg.go.dev/open-cluster-management.io/sdk-go@v0.13.0/pkg/cloudevents/generic#Codec) interface, featuring two essential methods: `Encode` for encoding the resource into cloudevents, and `Decode` for decoding cloudevents back into the resource. Refer to the [test/grpc_codec.go](../test/grpc_codec.go) for the example of the resource codec.
+
+3. Define resource lister that implements the [generic.Lister](https://pkg.go.dev/open-cluster-management.io/sdk-go/pkg/cloudevents/generic@v0.13.0#Lister) interface, it is used to list the resource objects on the source when resyncing the resources between sources and agents, for example, a hub controller can list the resources from the resource informers, and a RESTful service can list its resources from a database. Refer to the [test/store.go](../test/store.go) for the example of the resource codec.
+
+4. Define the resource status hash getter method - [generic.StatusHashGetter](https://pkg.go.dev/open-cluster-management.io/sdk-go/pkg/cloudevents/generic@v0.13.0#StatusHashGetter), this method will be used to calculate the resource status hash when resyncing the resource status between sources and agents. Refer to the [test/store.go](../test/store.go#L131) for the example of the resource codec.
+
+5. Then it's ready to call the [CloudEventSourceClient](https://pkg.go.dev/open-cluster-management.io/sdk-go/pkg/cloudevents/generic@v0.13.0#NewCloudEventSourceClient) method to initialize the gRPC source client.
+
+    ```golang
+    import generic "open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
+
+    // create the gRPC source client
+    grpcSourceCloudEventsClient, err := generic.NewCloudEventSourceClient[*api.Resource](
+        context.TODO(),
+        grpcSourceOption,
+        store,
+        resourceStatusHashGetter,
+        &ResourceCodec{},
+    )
+    ```
+
+### Publish the Resource
+
+To publish the resource with cloudevents format, you need to call the `Publish` method of the gRPC source client.
+
+```golang
+    // publish the resource in the cloudevents format
     grpcSourceCloudEventsClient.Publish(context.TODO(), types.CloudEventsType{
 		CloudEventsDataType: payload.ManifestEventDataType,
 		SubResource:         types.SubResourceSpec,
 		Action:              config.CreateRequestAction,
 	}, res)
 ```
-The `res` is the resource you want to publish. The format of the resource is defined:
-```
+
+The `Publish` method takes three arguments:
+- the context
+- the cloudevents type - deinfe the cloudevent data type in codec implementation
+- the resource - the resource you intend to publish, the codec will translate resource to and from cloudevents
+
+see the below for an example of the resource:
+
+```golang
     resource := &api.Resource{
 		ConsumerID: consumerID,
 		Manifest:   testManifest,
@@ -67,5 +98,17 @@ The `res` is the resource you want to publish. The format of the resource is def
         }
         }
     }`, &testManifest);
-	
 ```
+
+### Subscribe to the Resource Status
+
+To subscribe to the resource status, you need to call the `Subscribe` method of the gRPC source client with a callback function that handles the resource status.
+
+```golang
+    // start a go routine to sibscribe to the resources status
+    grpcSourceCloudEventsClient.Subscribe(ctx, func(action types.ResourceAction, resource *api.Resource) error {
+        // check the resource action and handle the resource status
+        return nil
+    })
+```
+

--- a/pkg/api/resource_types.go
+++ b/pkg/api/resource_types.go
@@ -15,6 +15,7 @@ import (
 type Resource struct {
 	Meta
 	Version    int32
+	Source     string
 	ConsumerID string
 	Manifest   datatypes.JSONMap
 	Status     datatypes.JSONMap

--- a/pkg/db/migrations/202311151850_add_resources.go
+++ b/pkg/db/migrations/202311151850_add_resources.go
@@ -10,6 +10,7 @@ import (
 func addResources() *gormigrate.Migration {
 	type Resource struct {
 		Model
+		Source     string         `gorm:"index"`
 		ConsumerID string         `gorm:"index"`
 		Version    int            `gorm:"not null"`
 		Manifest   datatypes.JSON `gorm:"type:json"`

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,0 +1,86 @@
+package event
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openshift-online/maestro/pkg/api"
+)
+
+// EventClient is a client that can receive resource status change events.
+type EventClient struct {
+	clusterName string
+	resChan     chan *api.Resource
+}
+
+// NewEventClient creates a new event client.
+func NewEventClient(clusterName string) *EventClient {
+	return &EventClient{
+		clusterName: clusterName,
+		resChan:     make(chan *api.Resource),
+	}
+}
+
+// Receive returns a channel that can be used to receive resource status change events.
+func (c *EventClient) Receive() <-chan *api.Resource {
+	return c.resChan
+}
+
+// EventHub is a hub that can broadcast resource status change events to registered clients.
+type EventHub struct {
+	mu sync.RWMutex
+
+	// Registered clients.
+	clients map[*EventClient]struct{}
+
+	// Inbound messages from the clients.
+	broadcast chan *api.Resource
+}
+
+// NewEventHub creates a new event hub.
+func NewEventHub() *EventHub {
+	return &EventHub{
+		clients:   make(map[*EventClient]struct{}),
+		broadcast: make(chan *api.Resource),
+	}
+}
+
+// Register registers a client.
+func (h *EventHub) Register(client *EventClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.clients[client] = struct{}{}
+}
+
+// Unregister unregisters a client.
+func (h *EventHub) Unregister(client *EventClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	delete(h.clients, client)
+	close(client.resChan)
+}
+
+// Broadcast broadcasts a resource status change event to all registered clients.
+func (h *EventHub) Broadcast(res *api.Resource) {
+	h.broadcast <- res
+}
+
+// Start starts the event hub and waits for events to broadcast.
+func (h *EventHub) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case res := <-h.broadcast:
+			h.mu.RLock()
+			for client := range h.clients {
+				if client.clusterName == res.ConsumerID || client.clusterName == "+" {
+					client.resChan <- res
+				}
+			}
+			h.mu.RUnlock()
+		}
+	}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -9,13 +9,15 @@ import (
 
 // EventClient is a client that can receive resource status change events.
 type EventClient struct {
+	source      string
 	clusterName string
 	resChan     chan *api.Resource
 }
 
 // NewEventClient creates a new event client.
-func NewEventClient(clusterName string) *EventClient {
+func NewEventClient(source, clusterName string) *EventClient {
 	return &EventClient{
+		source:      source,
 		clusterName: clusterName,
 		resChan:     make(chan *api.Resource),
 	}
@@ -76,7 +78,7 @@ func (h *EventHub) Start(ctx context.Context) {
 		case res := <-h.broadcast:
 			h.mu.RLock()
 			for client := range h.clients {
-				if client.clusterName == res.ConsumerID || client.clusterName == "+" {
+				if client.source == res.Source && (client.clusterName == res.ConsumerID || client.clusterName == "+") {
 					client.resChan <- res
 				}
 			}

--- a/templates/route-template.yml
+++ b/templates/route-template.yml
@@ -26,3 +26,18 @@ objects:
     tls:
       termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: maestro-grpc
+    labels:
+      app: maestro-grpc
+  spec:
+    host: maestro-grpc.${EXTERNAL_APPS_DOMAIN}
+    to:
+      kind: Service
+      name: maestro-grpc
+    tls:
+      termination: reencrypt
+      insecureEdgeTerminationPolicy: Redirect

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -371,7 +371,7 @@ objects:
         app: maestro
         port: metrics
       annotations:
-        description: Exposes and load balances the maestro pods metrics endpoint
+        description: Exposes and load balances the maestro pods restful api endpoint
         service.alpha.openshift.io/serving-cert-secret-name: maestro-metrics-tls
     spec:
       selector:
@@ -380,6 +380,24 @@ objects:
       - port: 8080
         targetPort: 8080
         name: metrics
+
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: maestro-grpc
+      labels:
+        app: maestro-grpc
+        port: grpc
+      annotations:
+        description: Exposes and load balances the maestro pods grpc endpoint
+        service.alpha.openshift.io/serving-cert-secret-name: maestro-tls
+    spec:
+      selector:
+        app: maestro
+      ports:
+        - port: 8090
+          targetPort: 8090
+          protocol: TCP
 
   - apiVersion: v1
     kind: Service

--- a/test/grpc_codec.go
+++ b/test/grpc_codec.go
@@ -1,14 +1,17 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cloudeventstypes "github.com/cloudevents/sdk-go/v2/types"
 	"github.com/openshift-online/maestro/pkg/api"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+	agentclient "open-cluster-management.io/sdk-go/pkg/cloudevents/work/agent/client"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/payload"
 )
 
@@ -83,6 +86,38 @@ func (c *ResourceCodec) Decode(evt *cloudevents.Event) (*api.Resource, error) {
 		},
 		Version:    int32(resourceVersion),
 		ConsumerID: clusterName,
+	}
+
+	resourceStatus := &api.ResourceStatus{
+		ReconcileStatus: &api.ReconcileStatus{
+			ObservedVersion: resourceVersion,
+		},
+	}
+
+	if manifestStatus.Status != nil {
+		resourceStatus.ReconcileStatus.Conditions = manifestStatus.Status.Conditions
+		if meta.IsStatusConditionTrue(manifestStatus.Conditions, agentclient.ManifestsDeleted) {
+			deletedCondition := meta.FindStatusCondition(manifestStatus.Conditions, agentclient.ManifestsDeleted)
+			resourceStatus.ReconcileStatus.Conditions = append(resourceStatus.ReconcileStatus.Conditions, *deletedCondition)
+		}
+		for _, value := range manifestStatus.Status.StatusFeedbacks.Values {
+			if value.Name == "status" {
+				contentStatus := make(map[string]interface{})
+				if err := json.Unmarshal([]byte(*value.Value.JsonRaw), &contentStatus); err != nil {
+					return nil, fmt.Errorf("failed to convert status feedback value to content status: %v", err)
+				}
+				resourceStatus.ContentStatus = contentStatus
+			}
+		}
+	}
+
+	resourceStatusJSON, err := json.Marshal(resourceStatus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource status: %v", err)
+	}
+	err = json.Unmarshal(resourceStatusJSON, &resource.Status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal resource status: %v", err)
 	}
 
 	return resource, nil

--- a/test/helper.go
+++ b/test/helper.go
@@ -13,8 +13,12 @@ import (
 	"time"
 
 	"github.com/openshift-online/maestro/pkg/controllers"
+	"github.com/openshift-online/maestro/pkg/event"
 	"github.com/openshift-online/maestro/pkg/logger"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
+	grpcoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
 	mqttoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/mqtt"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/agent/codec"
 
@@ -58,6 +62,9 @@ type TimeFunc func() time.Time
 type Helper struct {
 	Ctx context.Context
 
+	EventHub          *event.EventHub
+	Store             *MemoryStore
+	GRPCSourceClient  *generic.CloudEventSourceClient[*api.Resource]
 	DBFactory         db.SessionFactory
 	AppConfig         *config.ApplicationConfig
 	APIServer         server.Server
@@ -100,6 +107,7 @@ func NewHelper(t *testing.T) *Helper {
 
 		helper = &Helper{
 			Ctx:           context.Background(),
+			EventHub:      event.NewEventHub(),
 			AppConfig:     env.Config,
 			DBFactory:     env.Database.SessionFactory,
 			JWTPrivateKey: jwtKey,
@@ -113,6 +121,8 @@ func NewHelper(t *testing.T) *Helper {
 			jwkMockTeardown,
 			helper.stopAPIServer,
 		}
+
+		helper.startEventHub()
 		helper.startAPIServer()
 		helper.startMetricsServer()
 		helper.startHealthCheckServer()
@@ -138,7 +148,7 @@ func (helper *Helper) Teardown() {
 func (helper *Helper) startAPIServer() {
 	// TODO jwk mock server needs to be refactored out of the helper and into the testing environment
 	helper.Env().Config.HTTPServer.JwkCertURL = jwkURL
-	helper.APIServer = server.NewAPIServer()
+	helper.APIServer = server.NewAPIServer(helper.EventHub)
 	go func() {
 		glog.V(10).Info("Test API server started")
 		helper.APIServer.Start()
@@ -182,8 +192,16 @@ func (helper *Helper) startPulseServer(ctx context.Context) {
 	helper.Env().Config.PulseServer.SubscriptionType = "broadcast"
 	go func() {
 		glog.V(10).Info("Test pulse server started")
-		server.NewPulseServer().Start(ctx)
+		server.NewPulseServer(helper.EventHub).Start(ctx)
 		glog.V(10).Info("Test pulse server stopped")
+	}()
+}
+
+func (helper *Helper) startEventHub() {
+	go func() {
+		glog.V(10).Info("Test event hub started")
+		helper.EventHub.Start(helper.Ctx)
+		glog.V(10).Info("Test event hub stopped")
 	}()
 }
 
@@ -220,6 +238,30 @@ func (helper *Helper) StartWorkAgent(ctx context.Context, clusterName string, mq
 
 	go clientHolder.ManifestWorkInformer().Informer().Run(ctx.Done())
 	helper.WorkAgentHolder = clientHolder
+}
+
+func (helper *Helper) StartGRPCResourceSourceClient() {
+	store := NewStore()
+	grpcOptions := grpcoptions.NewGRPCOptions()
+	grpcOptions.URL = fmt.Sprintf("%s:%s", helper.Env().Config.HTTPServer.Hostname, helper.Env().Config.GRPCServer.BindPort)
+	sourceClient, err := generic.NewCloudEventSourceClient[*api.Resource](
+		helper.Ctx,
+		grpcoptions.NewSourceOptions(grpcOptions, "integration-grpc-test"),
+		store,
+		resourceStatusHashGetter,
+		&ResourceCodec{},
+	)
+
+	if err != nil {
+		glog.Fatalf("Unable to create grpc cloudevents source client: %s", err.Error())
+	}
+
+	sourceClient.Subscribe(helper.Ctx, func(action types.ResourceAction, resource *api.Resource) error {
+		return store.UpdateStatus(resource)
+	})
+
+	helper.Store = store
+	helper.GRPCSourceClient = sourceClient
 }
 
 func (helper *Helper) RestartServer() {

--- a/test/store.go
+++ b/test/store.go
@@ -1,0 +1,137 @@
+package test
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+)
+
+type MemoryStore struct {
+	sync.RWMutex
+	resources map[string]*api.Resource
+}
+
+func NewStore() *MemoryStore {
+	return &MemoryStore{
+		resources: make(map[string]*api.Resource),
+	}
+}
+
+func (s *MemoryStore) Add(resource *api.Resource) {
+	s.Lock()
+	defer s.Unlock()
+
+	if resource.ID == "" {
+		return
+	}
+
+	_, ok := s.resources[resource.ID]
+	if !ok {
+		s.resources[resource.ID] = resource
+	}
+}
+
+func (s *MemoryStore) Update(resource *api.Resource) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if resource.ID == "" {
+		return fmt.Errorf("the resource ID is empty")
+	}
+
+	_, ok := s.resources[resource.ID]
+	if !ok {
+		return fmt.Errorf("the resource %s does not exist", resource.ID)
+	}
+
+	s.resources[resource.ID] = resource
+
+	return nil
+}
+
+func (s *MemoryStore) UpSert(resource *api.Resource) {
+	s.Lock()
+	defer s.Unlock()
+
+	if resource.ID == "" {
+		return
+	}
+
+	s.resources[resource.ID] = resource
+}
+
+func (s *MemoryStore) UpdateStatus(resource *api.Resource) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if resource.ID == "" {
+		return fmt.Errorf("the resource ID is empty")
+	}
+
+	last, ok := s.resources[resource.ID]
+	if !ok {
+		return fmt.Errorf("the resource %s does not exist", resource.ID)
+	}
+
+	last.Status = resource.Status
+	s.resources[resource.ID] = last
+
+	return nil
+}
+
+func (s *MemoryStore) Delete(resourceID string) {
+	s.Lock()
+	defer s.Unlock()
+
+	if resourceID == "" {
+		return
+	}
+
+	delete(s.resources, resourceID)
+}
+
+func (s *MemoryStore) Get(resourceID string) (*api.Resource, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	resource, ok := s.resources[resourceID]
+	if !ok {
+		return nil, fmt.Errorf("failed to find resource %s", resourceID)
+	}
+
+	return resource, nil
+}
+
+func (s *MemoryStore) ListByNamespace(namespace string) []*api.Resource {
+	s.RLock()
+	defer s.RUnlock()
+
+	resources := make([]*api.Resource, len(s.resources))
+	i := 0
+	for _, res := range s.resources {
+		if res.ConsumerID != namespace {
+			continue
+		}
+
+		resources[i] = res
+		i++
+	}
+
+	return resources
+}
+
+func (s *MemoryStore) List(listOpts types.ListOptions) ([]*api.Resource, error) {
+	return s.ListByNamespace(listOpts.ClusterName), nil
+}
+
+func resourceStatusHashGetter(obj *api.Resource) (string, error) {
+	statusBytes, err := json.Marshal(obj.Status)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal resource status, %v", err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(statusBytes)), nil
+}


### PR DESCRIPTION
This PR tries to add resource status subscription with GRPC option.

```bash
# make test-integration
CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -ldflags="" ./cmd/maestro
OCM_ENV=testing gotestsum --format short-verbose -- -p 1 -ldflags -s -v -timeout 1h  \
		./test/integration
I0226 02:38:24.458788   62021 framework.go:76] Initializing testing environment
I0226 02:38:24.655981   62021 framework.go:161] Using Mock OCM Authz Client
I0226 02:38:24.657292   62021 framework.go:199] Disabling Sentry error reporting
I0226 02:38:24.663974   62021 grpc_server.go:69] Serving gRPC service without TLS at 8090
PASS test/integration.TestConsumerGet (0.34s)
PASS test/integration.TestConsumerPost (0.19s)
PASS test/integration.TestConsumerPaging (0.33s)
PASS test/integration.TestControllerRacing (1.60s)
PASS test/integration.TestControllerReconcile (1.29s)
PASS test/integration.TestControllerSync (1.32s)
PASS test/integration.TestPulseServer (5.20s)
PASS test/integration.TestResourceGet (0.28s)
PASS test/integration.TestResourcePost (5.31s)
PASS test/integration.TestResourcePatch (0.31s)
PASS test/integration.TestResourcePaging (0.28s)
PASS test/integration.TestResourceListSearch (0.36s)
PASS test/integration.TestUpdateResourceWithRacingRequests (0.39s)
PASS test/integration.TestResourceFromGRPC (4.31s)
I0226 02:38:46.198050   62021 api_server.go:157] Web server terminated
PASS test/integration

DONE 14 tests in 0.902s
```