### PR TITLE
Make integration test stable

### DIFF
--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -40,7 +40,7 @@ type ControllersServer struct {
 
 // Start is a blocking call that starts this controller server
 func (s ControllersServer) Start(ctx context.Context) {
-	log := logger.NewOCMLogger(context.Background())
+	log := logger.NewOCMLogger(ctx)
 
 	log.Infof("Kind controller handling events")
 	go s.KindControllerManager.Run(ctx.Done())

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	open-cluster-management.io/api v0.13.0
 	open-cluster-management.io/ocm v0.13.1-0.20240313094829-1c0c0156e780
-	open-cluster-management.io/sdk-go v0.13.1-0.20240313075541-00a94671ced1
+	open-cluster-management.io/sdk-go v0.13.1-0.20240321032811-7dbdd1b5c63d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1139,6 +1139,8 @@ open-cluster-management.io/ocm v0.13.1-0.20240313094829-1c0c0156e780 h1:Mu3TZwQp
 open-cluster-management.io/ocm v0.13.1-0.20240313094829-1c0c0156e780/go.mod h1:rC5GTnO4hhGY6lsYr1sdaCsCbpDZvWfuW1COunwGHAg=
 open-cluster-management.io/sdk-go v0.13.1-0.20240313075541-00a94671ced1 h1:s3dJdi1eol+/8ek6JQuaEuoGPkK/wRyM9zowqzKHPDY=
 open-cluster-management.io/sdk-go v0.13.1-0.20240313075541-00a94671ced1/go.mod h1:sq+amR9Ls9JzMP5dypvlCx4jIGfDg45gicS67Z/MnlI=
+open-cluster-management.io/sdk-go v0.13.1-0.20240321032811-7dbdd1b5c63d h1:mWrwuvY3K/MLfOLbwJB6VSNsdDol98fvK3hHXuDlxfQ=
+open-cluster-management.io/sdk-go v0.13.1-0.20240321032811-7dbdd1b5c63d/go.mod h1:sq+amR9Ls9JzMP5dypvlCx4jIGfDg45gicS67Z/MnlI=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/controllers/framework.go
+++ b/pkg/controllers/framework.go
@@ -129,6 +129,10 @@ func (km *KindControllerManager) handleEvent(id string) error {
 
 	event, svcErr := km.events.Get(reqContext, id)
 	if svcErr != nil {
+		if svcErr.Is404() {
+			// the event is already deleted, we can ignore it
+			return nil
+		}
 		return fmt.Errorf("error getting event with id(%s): %s", id, svcErr)
 	}
 

--- a/pkg/db/context.go
+++ b/pkg/db/context.go
@@ -10,7 +10,7 @@ import (
 // NewContext returns a new context with transaction stored in it.
 // Upon error, the original context is still returned along with an error
 func NewContext(ctx context.Context, connection SessionFactory) (context.Context, error) {
-	tx, err := newTransaction(ctx, connection)
+	tx, err := newTransaction(connection)
 	if err != nil {
 		return ctx, err
 	}

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -1,8 +1,6 @@
 package db
 
 import (
-	"context"
-
 	"github.com/openshift-online/maestro/pkg/db/transaction"
 )
 
@@ -11,7 +9,7 @@ import (
 const defaultRollbackPolicy = false
 
 // newTransaction constructs a new Transaction object.
-func newTransaction(ctx context.Context, connection SessionFactory) (*transaction.Transaction, error) {
+func newTransaction(connection SessionFactory) (*transaction.Transaction, error) {
 	if connection == nil {
 		// This happens in non-integration tests
 		return nil, nil

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -17,5 +17,6 @@ func TestMain(m *testing.M) {
 	helper := test.NewHelper(&testing.T{})
 	exitCode := m.Run()
 	helper.Teardown()
+	helper.CleanDB()
 	os.Exit(exitCode)
 }

--- a/test/integration/pulse_server_test.go
+++ b/test/integration/pulse_server_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestPulseServer(t *testing.T) {
 	h, _ := test.RegisterIntegration(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	instanceDao := dao.NewInstanceDao(&h.Env().Database.SessionFactory)
 	// insert two existing instances

--- a/test/registration.go
+++ b/test/registration.go
@@ -16,7 +16,7 @@ func RegisterIntegration(t *testing.T) (*Helper, *openapi.APIClient) {
 	// Create a new helper
 	helper := NewHelper(t)
 	// Reset the database to a seeded blank state
-	helper.DBFactory.ResetDB()
+	helper.ResetDB()
 	// Create an api client
 	client := helper.NewApiClient()
 


### PR DESCRIPTION
1. do not need to re-create DB for each test. Just cleanup the table contents instead.
2. fix `concurrent map writes` by adding sync lock
As per golang doc:
>  Map access is unsafe only when updates are occurring. As long as all goroutines are only reading—looking up elements in the map, including iterating through it using a for range loop—and not changing the map by assigning to elements or doing deletions, it is safe for them to access the map concurrently without synchronization.
3. adopt fix https://github.com/open-cluster-management-io/sdk-go/pull/26