### PR TITLE
Fix integration test flaky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ install: check-gopath
 # Examples:
 #   make test TESTFLAGS="-run TestSomething"
 test:
-	OCM_ENV=testing gotestsum --jsonfile-timing-events=$(unit_test_json_output) --format short-verbose -- -p 1 -v $(TESTFLAGS) \
+	OCM_ENV=testing gotestsum --jsonfile-timing-events=$(unit_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -v $(TESTFLAGS) \
 		./pkg/... \
 		./cmd/...
 .PHONY: test

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -128,6 +128,8 @@ func TestControllerReconcile(t *testing.T) {
 
 		s.Start(ctx)
 	}()
+	// wait for the listener to start
+	time.Sleep(100 * time.Millisecond)
 
 	consumer := h.CreateConsumer("cluster1")
 	_ = h.CreateResource(consumer.Name, 1)

--- a/test/integration/pulse_server_test.go
+++ b/test/integration/pulse_server_test.go
@@ -77,6 +77,13 @@ func TestPulseServer(t *testing.T) {
 			return err
 		}
 
+		if len(list) == 0 {
+			// no work synced yet, resync it now
+			if _, err := agentWorkClient.List(ctx, metav1.ListOptions{}); err != nil {
+				return err
+			}
+		}
+
 		// ensure there is only one work was synced on the cluster
 		if len(list) != 1 {
 			return fmt.Errorf("unexpected work list %v", list)

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -102,6 +102,13 @@ func TestResourcePost(t *testing.T) {
 			return err
 		}
 
+		if len(list) == 0 {
+			// no work synced yet, resync it now
+			if _, err := agentWorkClient.List(ctx, metav1.ListOptions{}); err != nil {
+				return err
+			}
+		}
+
 		// ensure there is only one work was synced on the cluster
 		if len(list) != 1 {
 			return fmt.Errorf("unexpected work list %v", list)
@@ -256,6 +263,13 @@ func TestResourcePatch(t *testing.T) {
 			return err
 		}
 
+		if len(list) == 0 {
+			// no work synced yet, resync it now
+			if _, err := agentWorkClient.List(ctx, metav1.ListOptions{}); err != nil {
+				return err
+			}
+		}
+
 		// ensure there is only one work was synced on the cluster
 		if len(list) != 1 {
 			return fmt.Errorf("unexpected work list %v", list)
@@ -399,7 +413,7 @@ func TestUpdateResourceWithRacingRequests(t *testing.T) {
 			return fmt.Errorf("there are %d unreleased advisory lock", count)
 		}
 		return nil
-	}, 5*time.Second, 1*time.Second).Should(Succeed())
+	}, 10*time.Second, 1*time.Second).Should(Succeed())
 }
 
 func TestResourceFromGRPC(t *testing.T) {

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -209,7 +209,6 @@ func TestResourcePatch(t *testing.T) {
 
 	// use the consumer id as the consumer name
 	consumer := h.CreateConsumer("")
-	res := h.CreateResource(consumer.ID, 1)
 
 	h.StartControllerManager(ctx)
 	h.StartWorkAgent(ctx, consumer.ID, h.Env().Config.MessageBroker.MQTTOptions, false)
@@ -218,7 +217,8 @@ func TestResourcePatch(t *testing.T) {
 	lister := informer.Lister().ManifestWorks(consumer.ID)
 	agentWorkClient := clientHolder.ManifestWorks(consumer.ID)
 
-	// POST responses per openapi spec: 201, 400, 409, 500
+	res := h.CreateResource(consumer.ID, 1)
+	Expect(res.Version).To(Equal(int32(1)))
 
 	// 200 OK
 	newRes := h.NewAPIResource(consumer.ID, 2)


### PR DESCRIPTION
fixed: https://github.com/openshift-online/maestro/issues/75

1. for the postgres listen and notify, you have to ensure the listener to start prior to the notifier.
2. in some cases, the cache cannot be initialized successfully so that you have to manually trigger resync