### PR TITLE
Support loading image to e2e KinD cluster with `podman`

### DIFF
--- a/test/e2e/setup/e2e_setup.sh
+++ b/test/e2e/setup/e2e_setup.sh
@@ -45,6 +45,7 @@ if command -v docker &> /dev/null; then
 elif command -v podman &> /dev/null; then
     podman save ${external_image_registry}/${namespace}/maestro:$image_tag -o /tmp/maestro.tar 
     kind load image-archive /tmp/maestro.tar --name maestro 
+    rm /tmp/maestro.tar
 else 
     echo "Neither Docker nor Podman is installed, exiting"
     exit 1


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

It occurs the following error when running the e2e. The reference issue is from here https://github.com/kubernetes-sigs/kind/issues/2038.
```bash
$ kind load docker-image image-registry.testing/maestro/maestro:latest --name maestro           1 ↵
enabling experimental podman provider
ERROR: image: "image-registry.testing/maestro/maestro:latest" not present locally
```

Checking the image after fixing the issue:
```bash
$ podman exec maestro-control-plane crictl images
IMAGE                                      TAG                  IMAGE ID            SIZE
docker.io/kindest/kindnetd                 v20230511-dc714da8   b18bf71b941ba       25.3MB
docker.io/kindest/local-path-helper        v20230510-486859a6   d022557af8b63       2.92MB
docker.io/kindest/local-path-provisioner   v20230511-dc714da8   eec7db0a07d0d       17.3MB
image-registry.testing/maestro/maestro     latest               3dd8eaa761281       266MB
registry.k8s.io/coredns/coredns            v1.10.1              97e04611ad434       14.6MB
registry.k8s.io/etcd                       3.5.7-0              24bc64e911039       80.7MB
registry.k8s.io/kube-apiserver             v1.27.3              634c53edb5c14       79.8MB
registry.k8s.io/kube-controller-manager    v1.27.3              aea4f169db16d       71.5MB
registry.k8s.io/kube-proxy                 v1.27.3              278dd40f83dfb       68.1MB
registry.k8s.io/kube-scheduler             v1.27.3              6234a065dec4c       57.6MB
registry.k8s.io/pause                      3.7                  e5a475a038057       268kB
```