### PR TITLE
maestro agent template for ARO-HCP

### DIFF
--- a/templates/agent-template-aro-hcp.yml
+++ b/templates/agent-template-aro-hcp.yml
@@ -1,0 +1,295 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: maestro-agent
+  annotations:
+    openshift.io/display-name: maestro-agent
+    description: agent to connect to maestro service.
+    tags: maestro-agent
+    iconClass: icon-shadowman
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    template.openshift.io/documentation-url: https://gitlab.cee.redhat.com/service/
+labels:
+  template: maestro-agent
+parameters:
+
+- name: AGENT_NAMESPACE
+  description: namespace of maestro agent
+
+- name: AGENT_SA
+  description: name of the agent service account
+  default: maestro
+
+- name: IMAGE_REGISTRY
+  displayName: Image Registry
+  required: true
+
+- name: IMAGE_REPOSITORY
+  displayName: Image Repository
+  required: true
+
+- name: IMAGE_TAG
+  displayName: Image tag
+  value: latest
+
+objects:
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: appliedmanifestworks.work.open-cluster-management.io
+  spec:
+    group: work.open-cluster-management.io
+    names:
+      kind: AppliedManifestWork
+      listKind: AppliedManifestWorkList
+      plural: appliedmanifestworks
+      singular: appliedmanifestwork
+    scope: Cluster
+    preserveUnknownFields: false
+    versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: AppliedManifestWork represents an applied manifestwork on managed cluster that is placed on a managed cluster. An AppliedManifestWork links to a manifestwork on a hub recording resources deployed in the managed cluster. When the agent is removed from managed cluster, cluster-admin on managed cluster can delete appliedmanifestwork to remove resources deployed by the agent. The name of the appliedmanifestwork must be in the format of {hash of hub's first kube-apiserver url}-{manifestwork name}
+            type: object
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec represents the desired configuration of AppliedManifestWork.
+                type: object
+                properties:
+                  agentID:
+                    description: AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.
+                    type: string
+                  hubHash:
+                    description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
+                    type: string
+                  manifestWorkName:
+                    description: ManifestWorkName represents the name of the related manifestwork on the hub.
+                    type: string
+              status:
+                description: Status represents the current status of AppliedManifestWork.
+                type: object
+                properties:
+                  appliedResources:
+                    description: AppliedResources represents a list of resources defined within the manifestwork that are applied. Only resources with valid GroupVersionResource, namespace, and name are suitable. An item in this slice is deleted when there is no mapped manifest in manifestwork.Spec or by finalizer. The resource relating to the item will also be removed from managed cluster. The deleted resource may still be present until the finalizers for that resource are finished. However, the resource will not be undeleted, so it can be removed from this list and eventual consistency is preserved.
+                    type: array
+                    items:
+                      description: AppliedManifestResourceMeta represents the group, version, resource, name and namespace of a resource. Since these resources have been created, they must have valid group, version, resource, namespace, and name.
+                      type: object
+                      required:
+                        - name
+                        - resource
+                        - version
+                      properties:
+                        group:
+                          description: Group is the API Group of the Kubernetes resource, empty string indicates it is in core group.
+                          type: string
+                        name:
+                          description: Name is the name of the Kubernetes resource.
+                          type: string
+                        namespace:
+                          description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
+                          type: string
+                        resource:
+                          description: Resource is the resource name of the Kubernetes resource.
+                          type: string
+                        uid:
+                          description: UID is set on successful deletion of the Kubernetes resource by controller. The resource might be still visible on the managed cluster after this field is set. It is not directly settable by a client.
+                          type: string
+                        version:
+                          description: Version is the version of the Kubernetes resource.
+                          type: string
+                  evictionStartTime:
+                    description: 'EvictionStartTime represents the current appliedmanifestwork will be evicted after a grace period. An appliedmanifestwork will be evicted from the managed cluster in the following two scenarios:   - the manifestwork of the current appliedmanifestwork is missing on the hub, or   - the appliedmanifestwork hub hash does not match the current hub hash of the work agent.'
+                    type: string
+                    format: date-time
+        served: true
+        storage: true
+        subresources:
+          status: {}
+  status:
+    acceptedNames:
+      kind: ""
+      plural: ""
+    conditions: []
+    storedVersions: []
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: maestro-agent:agent
+  rules:
+  # Allow agent to managed appliedmanifestworks
+  - apiGroups: ["work.open-cluster-management.io"]
+    resources: ["appliedmanifestworks"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["work.open-cluster-management.io"]
+    resources: ["appliedmanifestworks/status"]
+    verbs: ["patch", "update"]
+  - apiGroups: ["work.open-cluster-management.io"]
+    resources: ["appliedmanifestworks/finalizers"]
+    verbs: ["update"]
+  # Allow agent to check executor permissions
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: maestro-agent:agent
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: maestro-agent:agent
+  subjects:
+    - kind: ServiceAccount
+      name: ${AGENT_SA}
+      namespace: ${AGENT_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: maestro-agent:execution-admin
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    # We deploy a controller that could work with permission lower than cluster-admin, the tradeoff is
+    # responsivity because list/watch cannot be maintained over too many namespaces.
+    name: cluster-admin
+  subjects:
+    - kind: ServiceAccount
+      name: ${AGENT_SA}
+      namespace: ${AGENT_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: maestro-agent:execution
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: maestro-agent:execution
+  subjects:
+    - kind: ServiceAccount
+      name: ${AGENT_SA}
+      namespace: ${AGENT_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: maestro-agent:agent
+    namespace: ${AGENT_NAMESPACE}
+  rules:
+  # leader election needs to operate configmaps
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "list", "update", "watch", "patch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: maestro-agent:agent
+    namespace: ${AGENT_NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: maestro-agent:agent
+  subjects:
+    - kind: ServiceAccount
+      name: ${AGENT_SA}
+      namespace: ${AGENT_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: maestro-agent:agent:extension-apiserver
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: maestro-agent:agent:extension-apiserver
+  subjects:
+    - kind: ServiceAccount
+      name: ${AGENT_SA}
+      namespace: ${AGENT_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: maestro-agent:agent:extension-apiserver
+    namespace: kube-system
+  rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+
+- kind: Deployment
+  apiVersion: apps/v1
+  metadata:
+    name: maestro-agent
+    labels:
+      app: maestro-agent
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: maestro-agent
+    template:
+      metadata:
+        labels:
+          app: maestro-agent
+      spec:
+        serviceAccountName: ${AGENT_SA}
+        containers:
+        - name: maestro-agent
+          image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/maestro
+            - agent
+            - --consumer-name=$(CONSUMER_NAME)
+            - --message-broker-type=mqtt
+            - --message-broker-config-file=/secrets/mqtt/config.yaml
+            - --agent-client-id=$(CONSUMER_NAME)-work-agent
+          env:
+          - name: CONSUMER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: maestro-mqtt
+                key: consumer-name.cfg
+          volumeMounts:
+          - name: mqtt
+            mountPath: /secrets/mqtt
+          - name: mqtt-creds
+            mountPath: /secrets/mqtt-creds
+            readOnly: true
+        volumes:
+        - name: mqtt
+          secret:
+            secretName: maestro-mqtt
+        - name: mqtt-creds
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "maestro"

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -243,7 +243,8 @@ objects:
             - --db-name-file=/secrets/db/db.name
             - --db-rootcert=/secrets/db/db.ca_cert
             - --db-sslmode=${DB_SSLMODE}
-            - --mqtt-config-file=/secrets/mqtt/config.yaml
+            - --message-broker-config-file=/secrets/mqtt/config.yaml
+            - --message-broker-type=mqtt
             - --enable-ocm-mock=${ENABLE_OCM_MOCK}
             - --enable-jwt=${ENABLE_JWT}
             - --enable-https=${ENABLE_HTTPS}


### PR DESCRIPTION
the `agent-template-aro-hcp.yml` template fits the deployment model of the maestro agent on an ARO-HCP management cluster.

major differences towards the existing `agent-template.yml`

* it leverages CSI secret store to get ahold of the certificate to authenticate towards the MQTT broker
* it reads the consumer name from a secret expected within the deployment namespace

part of https://issues.redhat.com/browse/ARO-7234