### PR TITLE
deploy maestro with docker option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ environment:=${USER}
 namespace ?= maestro-${USER}
 agent_namespace ?= maestro-agent-${USER}
 
-# a tool for managing containers and images, etc. You can set it as docker
-container_tool ?= podman
+# a tool for managing containers and images, etc. Podman or Docker
+container_tool ?= $(shell command -v podman >/dev/null 2>&1 && echo podman || (command -v docker >/dev/null 2>&1 && echo docker))
 
 # In the development environment we are pushing the image directly to the image
 # registry inside the development cluster. That registry has a different name

--- a/README.md
+++ b/README.md
@@ -321,13 +321,9 @@ Login Succeeded!
 
 Deploy maestro:
 
-Before deploying maestro to the Openshift cluster, we will first build image. By default, the container tool is `podman`, but you can override it to use `docker` when necessary.
-```shell
-$ export container_tool=docker
-```
+We will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman. You can also customize the image with the environment variables `external_image_registry`, `image_repository` and `image_tag`. 
 
-Then we will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman. You can also specific the image information with the environment variables `external_image_registry`, `image_repository` and `image_tag`
-
+> Note: The meastro image pulled during deploying comes from the `internal_image_registry`, be sure to specify the correct value for the registry.
 
 ```shell
 $ make deploy

--- a/README.md
+++ b/README.md
@@ -321,9 +321,7 @@ Login Succeeded!
 
 Deploy maestro:
 
-We will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman. You can also customize the image with the environment variables `external_image_registry`, `image_repository` and `image_tag`. 
-
-> Note: The meastro image pulled during deploying comes from the `internal_image_registry`, be sure to specify the correct value for the registry.
+We will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman.
 
 ```shell
 $ make deploy

--- a/README.md
+++ b/README.md
@@ -321,7 +321,13 @@ Login Succeeded!
 
 Deploy maestro:
 
-We will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman.
+Before deploying maestro to the Openshift cluster, we will first build image. By default, the container tool is `podman`, but you can override it to use `docker` when necessary.
+```shell
+$ export container_tool=docker
+```
+
+Then we will push the image to your OpenShift cluster default registry and then deploy it to the cluster. You need to follow [this document](https://docs.openshift.com/container-platform/4.13/registry/securing-exposing-registry.html) to expose a default registry manually and login into the registry with podman. You can also specific the image information with the environment variables `external_image_registry`, `image_repository` and `image_tag`
+
 
 ```shell
 $ make deploy


### PR DESCRIPTION
I try to deploy the meastro to the openshift cluster. It throws the following error message:
```bash
make deploy
for cmd in $(ls cmd); do \
        go build \
                -ldflags="" \
                -o "${cmd}" \
                "./cmd/${cmd}" \
                || exit 1; \
done
podman build -t "default-route-openshift-image-registry.apps.obs-hub-of-hubs-aws-414-sno-lrqtk.scale.red-chesterfield.com/maestro-myan/maestro:1716775881" .
/bin/sh: line 1: podman: command not found
make: *** [Makefile:314: image] Error 127
```