### PR TITLE
refactor maestro agent flags.

### DIFF
--- a/cmd/maestro/agent/cmd.go
+++ b/cmd/maestro/agent/cmd.go
@@ -31,7 +31,7 @@ func NewAgentCommand() *cobra.Command {
 	agentOption.CloudEventsClientCodecs = []string{"manifest", "manifestbundle"}
 	cfg := spoke.NewWorkAgentConfig(commonOptions, agentOption)
 	cmdConfig := commonOptions.CommoOpts.
-		NewControllerCommandConfig("work-agent", version.Get(), cfg.RunWorkloadAgent)
+		NewControllerCommandConfig("maestro-agent", version.Get(), cfg.RunWorkloadAgent)
 
 	cmd := cmdConfig.NewCommandWithContext(context.TODO())
 	cmd.Use = "agent"

--- a/templates/agent-template-aro-hcp.yml
+++ b/templates/agent-template-aro-hcp.yml
@@ -268,9 +268,9 @@ objects:
             - /usr/local/bin/maestro
             - agent
             - --consumer-name=$(CONSUMER_NAME)
-            - --message-broker-type=mqtt
-            - --message-broker-config-file=/secrets/mqtt/config.yaml
-            - --agent-client-id=$(CONSUMER_NAME)-work-agent
+            - --workload-source-driver=mqtt
+            - --workload-source-config=/secrets/mqtt/config.yaml
+            - --cloudevents-client-id=$(CONSUMER_NAME)-work-agent
           env:
           - name: CONSUMER_NAME
             valueFrom:

--- a/templates/agent-template.yml
+++ b/templates/agent-template.yml
@@ -289,9 +289,9 @@ objects:
             - /usr/local/bin/maestro
             - agent
             - --consumer-name=${CONSUMER_NAME}
-            - --message-broker-type=mqtt
-            - --message-broker-config-file=/secrets/mqtt/config.yaml
-            - --agent-client-id=${CONSUMER_NAME}-work-agent
+            - --workload-source-driver=mqtt
+            - --workload-source-config=/secrets/mqtt/config.yaml
+            - --cloudevents-client-id=${CONSUMER_NAME}-work-agent
           volumeMounts:
           - name: mqtt
             mountPath: /secrets/mqtt


### PR DESCRIPTION
Refactor maestro agent flags:
1.  Enable manifest & manifestbundle codec for maestro agent.
2. Disable leader election by default, but can be enabled explicitly by flags when running agent in multiple instances.