### PR TITLE
Failed to update server instance heartbeat to the database

### DIFF
--- a/pkg/dao/instance.go
+++ b/pkg/dao/instance.go
@@ -61,7 +61,7 @@ func (d *sqlInstanceDao) Replace(ctx context.Context, instance *api.ServerInstan
 
 func (d *sqlInstanceDao) UpSert(ctx context.Context, instance *api.ServerInstance) (*api.ServerInstance, error) {
 	g2 := (*d.sessionFactory).New(ctx)
-	if err := g2.Omit(clause.Associations).Save(instance).Error; err != nil {
+	if err := g2.Unscoped().Omit(clause.Associations).Save(instance).Error; err != nil {
 		db.MarkForRollback(ctx, err)
 		return nil, err
 	}


### PR DESCRIPTION
When the maestro server is down for a while, it's up again. It might not sync its heartbeat to the database causing the following reasons:
```bash
E0612 09:28:05.379536   72292 logger.go:129]   failed to mark transaction for rollback: could not retrieve transaction from context 
E0612 09:28:05.380320   72292 logger.go:129]   Unable to upsert maestro instance: pq: duplicate key value violates unique constraint "server_instances_pkey" 
```

So the behavior will be:
1. The server is up, update the heartbeat
2. The server is down, then the liveness goroutine will mark the server as deleted if it reaches a specific duration
3. The server is up again, it will update the the heartbeat to the database and then mark the `deleted_at` as null


Reference: https://github.com/openshift-online/maestro/issues/109
Signed-off-by: myan <myan@redhat.com>

