### PR TITLE
Update base image

### DIFF
--- a/Containerfile.rhtap
+++ b/Containerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
 
 ENV SOURCE_DIR=/maestro
 WORKDIR $SOURCE_DIR
@@ -23,7 +23,7 @@ COPY --from=builder \
 
 EXPOSE 8000
 
-ENTRYPOINT ["/usr/local/bin/maestro", "serve"]
+ENTRYPOINT ["/usr/local/bin/maestro", "server"]
 
 LABEL name="maestro" \
       vendor="Red Hat, Inc." \


### PR DESCRIPTION
fixes: `[1/2] STEP 1/7: FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
Trying to pull brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20...
Error: creating build container: initializing source docker://brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20: unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication`