### PR TITLE
Add e2e test for readonly manifestwork via gRPC

### DIFF
--- a/test/e2e/pkg/suite_test.go
+++ b/test/e2e/pkg/suite_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -10,11 +11,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/source/codec"
 
 	"github.com/openshift-online/maestro/pkg/api/openapi"
+	"github.com/openshift-online/maestro/pkg/client/cloudevents/grpcsource"
 	"github.com/openshift-online/maestro/test"
 )
 
@@ -27,6 +33,11 @@ var (
 	apiClient         *openapi.APIClient
 	helper            *test.Helper
 	T                 *testing.T
+	workClient        *work.ClientHolder
+	grpcOptions       *grpc.GRPCOptions
+	cancel            context.CancelFunc
+	ctx               context.Context
+	sourceID          string
 )
 
 func TestE2E(t *testing.T) {
@@ -87,8 +98,23 @@ var _ = BeforeSuite(func() {
 	if consumer_name == "" {
 		panic("consumer_id is not provided")
 	}
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	sourceID = "sourceclient-test" + rand.String(5)
+	grpcOptions = grpc.NewGRPCOptions()
+	grpcOptions.URL = grpcServerAddress
+
+	workClient, err = work.NewClientHolderBuilder(grpcOptions).
+		WithClientID(fmt.Sprintf("%s-watcher", sourceID)).
+		WithSourceID(sourceID).
+		WithCodecs(codec.NewManifestBundleCodec()).
+		WithWorkClientWatcherStore(grpcsource.NewRESTFullAPIWatcherStore(apiClient, sourceID)).
+		WithResyncEnabled(false).
+		NewSourceClientHolder(ctx)
+	Expect(err).ShouldNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
-	// later...
+	cancel()
 })


### PR DESCRIPTION
write e2e test to get the secret from the target cluster via create manifestwork. use workclient to create the manifestwork with `readonly` option.