### PR TITLE
Add e2e test for broadcast subscription type of resource status update

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Setup kind
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.17.0
       - name: install ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
       - name: Test E2E
@@ -34,3 +30,24 @@ jobs:
           make e2e-test
         env:
           container_tool: docker
+  e2e-broadcast-subscription:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      # - name: Setup kind
+      #   uses: engineerd/setup-kind@v0.5.0
+      #   with:
+      #     version: v0.17.0
+      - name: install ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+      - name: Test E2E
+        run: |
+          make e2e-test
+        env:
+          container_tool: docker
+          ENABLE_BROADCAST_SUBSCRIPTION: true


### PR DESCRIPTION
This PR adds an E2E test for scenarios where the MQTT broker doesn't support shared subscriptions, requiring the use of broadcast subscription for the resource status dispatcher.