### PR TITLE
Consumer deletion

### DIFF
--- a/cmd/maestro/environments/service_types.go
+++ b/cmd/maestro/environments/service_types.go
@@ -49,6 +49,7 @@ func NewConsumerServiceLocator(env *Env) ConsumerServiceLocator {
 		return services.NewConsumerService(
 			db.NewAdvisoryLockFactory(env.Database.SessionFactory),
 			dao.NewConsumerDao(&env.Database.SessionFactory),
+			dao.NewResourceDao(&env.Database.SessionFactory),
 			env.Services.Events(),
 		)
 	}

--- a/cmd/maestro/server/routes.go
+++ b/cmd/maestro/server/routes.go
@@ -23,7 +23,7 @@ func (s *apiServer) routes() *mux.Router {
 	}
 
 	resourceHandler := handlers.NewResourceHandler(services.Resources(), services.Generic())
-	consumerHandler := handlers.NewConsumerHandler(services.Consumers(), services.Generic())
+	consumerHandler := handlers.NewConsumerHandler(services.Consumers(), services.Resources(), services.Generic())
 	errorsHandler := handlers.NewErrorsHandler()
 
 	var authMiddleware auth.JWTMiddleware

--- a/pkg/dao/mocks/consumer.go
+++ b/pkg/dao/mocks/consumer.go
@@ -38,7 +38,7 @@ func (d *consumerDaoMock) Replace(ctx context.Context, consumer *api.Consumer) (
 	return nil, errors.NotImplemented("Consumer").AsError()
 }
 
-func (d *consumerDaoMock) Delete(ctx context.Context, id string) error {
+func (d *consumerDaoMock) Delete(ctx context.Context, id string, unscoped bool) error {
 	return errors.NotImplemented("Consumer").AsError()
 }
 

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -81,3 +81,7 @@ func (d *resourceDaoMock) FindBySource(ctx context.Context, source string) (api.
 func (d *resourceDaoMock) All(ctx context.Context) (api.ResourceList, error) {
 	return d.resources, nil
 }
+
+func (d *resourceDaoMock) FirstByConsumerName(ctx context.Context, consumerName string) (api.Resource, error) {
+	return *d.resources[0], errors.NotImplemented("Resource").AsError()
+}

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -82,6 +82,6 @@ func (d *resourceDaoMock) All(ctx context.Context) (api.ResourceList, error) {
 	return d.resources, nil
 }
 
-func (d *resourceDaoMock) FirstByConsumerName(ctx context.Context, consumerName string) (api.Resource, error) {
+func (d *resourceDaoMock) FirstByConsumerName(ctx context.Context, consumerName string, unscoped bool) (api.Resource, error) {
 	return *d.resources[0], errors.NotImplemented("Resource").AsError()
 }

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -19,6 +19,7 @@ type ResourceDao interface {
 	FindBySource(ctx context.Context, source string) (api.ResourceList, error)
 	FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error)
 	All(ctx context.Context) (api.ResourceList, error)
+	FirstByConsumerName(ctx context.Context, name string) (api.Resource, error)
 }
 
 var _ ResourceDao = &sqlResourceDao{}
@@ -114,4 +115,11 @@ func (d *sqlResourceDao) All(ctx context.Context) (api.ResourceList, error) {
 		return nil, err
 	}
 	return resources, nil
+}
+
+func (d *sqlResourceDao) FirstByConsumerName(ctx context.Context, consumerName string) (api.Resource, error) {
+	g2 := (*d.sessionFactory).New(ctx)
+	resource := api.Resource{}
+	err := g2.Where("consumer_name = ?", consumerName).First(&resource).Error
+	return resource, err
 }

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -117,7 +117,7 @@ func (d *sqlResourceDao) All(ctx context.Context) (api.ResourceList, error) {
 	return resources, nil
 }
 
-// FirstByConsumerName will take the first item of the resources. Currently leverage it to determine whether the result exists in the table.
+// FirstByConsumerName will take the first item of the resources on the consumer. it can be used to determine whether the resource exists for the consumer.
 func (d *sqlResourceDao) FirstByConsumerName(ctx context.Context, consumerName string, unscoped bool) (api.Resource, error) {
 	g2 := (*d.sessionFactory).New(ctx)
 	if unscoped {

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -19,7 +19,7 @@ type ResourceDao interface {
 	FindBySource(ctx context.Context, source string) (api.ResourceList, error)
 	FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error)
 	All(ctx context.Context) (api.ResourceList, error)
-	FirstByConsumerName(ctx context.Context, name string) (api.Resource, error)
+	FirstByConsumerName(ctx context.Context, name string, unscoped bool) (api.Resource, error)
 }
 
 var _ ResourceDao = &sqlResourceDao{}
@@ -117,8 +117,13 @@ func (d *sqlResourceDao) All(ctx context.Context) (api.ResourceList, error) {
 	return resources, nil
 }
 
-func (d *sqlResourceDao) FirstByConsumerName(ctx context.Context, consumerName string) (api.Resource, error) {
+// FirstByConsumerName will take the first item of the resources. Currently leverage it to determine whether the result exists in the table.
+func (d *sqlResourceDao) FirstByConsumerName(ctx context.Context, consumerName string, unscoped bool) (api.Resource, error) {
 	g2 := (*d.sessionFactory).New(ctx)
+	if unscoped {
+		// Unscoped is used to find the deleting resources
+		g2 = g2.Unscoped()
+	}
 	resource := api.Resource{}
 	err := g2.Where("consumer_name = ?", consumerName).First(&resource).Error
 	return resource, err

--- a/pkg/handlers/consumer.go
+++ b/pkg/handlers/consumer.go
@@ -17,12 +17,14 @@ var _ RestHandler = consumerHandler{}
 
 type consumerHandler struct {
 	consumer services.ConsumerService
+	resource services.ResourceService
 	generic  services.GenericService
 }
 
-func NewConsumerHandler(consumer services.ConsumerService, generic services.GenericService) *consumerHandler {
+func NewConsumerHandler(consumer services.ConsumerService, resource services.ResourceService, generic services.GenericService) *consumerHandler {
 	return &consumerHandler{
 		consumer: consumer,
+		resource: resource,
 		generic:  generic,
 	}
 }

--- a/pkg/handlers/consumer.go
+++ b/pkg/handlers/consumer.go
@@ -84,7 +84,7 @@ func (h consumerHandler) List(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			listArgs := services.NewListArguments(r.URL.Query())
-			var consumers = []api.Consumer{}
+			consumers := []api.Consumer{}
 			paging, err := h.generic.List(ctx, "username", listArgs, &consumers)
 			if err != nil {
 				return nil, err
@@ -135,7 +135,11 @@ func (h consumerHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h consumerHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	cfg := &handlerConfig{
 		Action: func() (interface{}, *errors.ServiceError) {
-			return nil, errors.NotImplemented("delete")
+			id := mux.Vars(r)["id"]
+			if err := h.consumer.Delete(r.Context(), id); err != nil {
+				return nil, err
+			}
+			return nil, nil
 		},
 	}
 	handleDelete(w, r, cfg, http.StatusNoContent)

--- a/pkg/services/consumer.go
+++ b/pkg/services/consumer.go
@@ -76,7 +76,7 @@ func (s *sqlConsumerService) Delete(ctx context.Context, id string) *errors.Serv
 	}
 
 	if e != gorm.ErrRecordNotFound {
-		return handleGetError("Resource", "consumer_name", consumer.Name, e)
+		return errors.GeneralError("Unable to get resources by consumer: %s", e)
 	}
 
 	// e is record not found

--- a/pkg/services/consumer.go
+++ b/pkg/services/consumer.go
@@ -86,7 +86,7 @@ func (s *sqlConsumerService) Delete(ctx context.Context, id string) *errors.Serv
 
 	// e is record not found
 	if err := s.consumerDao.Delete(ctx, id, true); err != nil {
-		return handleDeleteError("Consumer", errors.GeneralError("Unable to delete consumer: %s", err))
+		return handleDeleteError("Consumer", err)
 	}
 	return nil
 }

--- a/pkg/services/consumer.go
+++ b/pkg/services/consumer.go
@@ -64,26 +64,11 @@ func (s *sqlConsumerService) Replace(ctx context.Context, consumer *api.Consumer
 	return consumer, nil
 }
 
-// Delete will remove the consumer from the storage. Currently, it will:
+// Delete will remove the consumer from the storage:
 // 1. Perform a hard delete on the consumer, the resource creation will be blocked after it.
-// 2. Forbid consumer deletion if there are associated resources.
-// 3. The deleting resources(marked as deleted) will still block the consumer deletion.
-// TODO: Additional deletion options or strategies may be added in the future.
+// 2. Forbid consumer deletion if there are associated resources(include the marked as deleted resources).
+// TODO: Add deletion options or strategies.
 func (s *sqlConsumerService) Delete(ctx context.Context, id string) *errors.ServiceError {
-	// TODO: The following code snippet is for soft deleting a consumer
-	// consumer, err := s.Get(ctx, id)
-	// if err != nil {
-	// 	return err
-	// }
-	// _, e := s.resourceDao.FirstByConsumerName(ctx, consumer.Name, true)
-	// if e == nil {
-	// 	return errors.Forbidden("Resources associated with the consumer: %s", consumer.Name)
-	// }
-	// if e != gorm.ErrRecordNotFound {
-	// 	return handleDeleteError("Consumer", e)
-	// }
-	// then resource is not found for the consumer
-
 	if err := s.consumerDao.Delete(ctx, id, true); err != nil {
 		return handleDeleteError("Consumer", err)
 	}

--- a/pkg/services/consumer.go
+++ b/pkg/services/consumer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/openshift-online/maestro/pkg/dao"
 	"github.com/openshift-online/maestro/pkg/db"
-	"gorm.io/gorm"
 
 	"github.com/openshift-online/maestro/pkg/api"
 	"github.com/openshift-online/maestro/pkg/errors"
@@ -71,20 +70,20 @@ func (s *sqlConsumerService) Replace(ctx context.Context, consumer *api.Consumer
 // 3. The deleting resources(marked as deleted) will still block the consumer deletion.
 // TODO: Additional deletion options or strategies may be added in the future.
 func (s *sqlConsumerService) Delete(ctx context.Context, id string) *errors.ServiceError {
-	consumer, err := s.Get(ctx, id)
-	if err != nil {
-		return err
-	}
-	_, e := s.resourceDao.FirstByConsumerName(ctx, consumer.Name, true)
-	if e == nil {
-		return errors.Forbidden("Resources associated with the consumer: %s", consumer.Name)
-	}
+	// TODO: The following code snippet is for soft deleting a consumer
+	// consumer, err := s.Get(ctx, id)
+	// if err != nil {
+	// 	return err
+	// }
+	// _, e := s.resourceDao.FirstByConsumerName(ctx, consumer.Name, true)
+	// if e == nil {
+	// 	return errors.Forbidden("Resources associated with the consumer: %s", consumer.Name)
+	// }
+	// if e != gorm.ErrRecordNotFound {
+	// 	return handleDeleteError("Consumer", e)
+	// }
+	// then resource is not found for the consumer
 
-	if e != gorm.ErrRecordNotFound {
-		return errors.GeneralError("Unable to get resources by consumer: %s", e)
-	}
-
-	// e is record not found
 	if err := s.consumerDao.Delete(ctx, id, true); err != nil {
 		return handleDeleteError("Consumer", err)
 	}

--- a/pkg/services/consumer.go
+++ b/pkg/services/consumer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift-online/maestro/pkg/dao"
 	"github.com/openshift-online/maestro/pkg/db"
+	"gorm.io/gorm"
 
 	"github.com/openshift-online/maestro/pkg/api"
 	"github.com/openshift-online/maestro/pkg/errors"
@@ -20,9 +21,10 @@ type ConsumerService interface {
 	FindByIDs(ctx context.Context, ids []string) (api.ConsumerList, *errors.ServiceError)
 }
 
-func NewConsumerService(lockFactory db.LockFactory, consumerDao dao.ConsumerDao, events EventService) ConsumerService {
+func NewConsumerService(lockFactory db.LockFactory, consumerDao dao.ConsumerDao, resourceDao dao.ResourceDao, events EventService) ConsumerService {
 	return &sqlConsumerService{
 		consumerDao: consumerDao,
+		resourceDao: resourceDao,
 	}
 }
 
@@ -30,6 +32,7 @@ var _ ConsumerService = &sqlConsumerService{}
 
 type sqlConsumerService struct {
 	consumerDao dao.ConsumerDao
+	resourceDao dao.ResourceDao
 }
 
 func (s *sqlConsumerService) Get(ctx context.Context, id string) (*api.Consumer, *errors.ServiceError) {
@@ -63,6 +66,20 @@ func (s *sqlConsumerService) Replace(ctx context.Context, consumer *api.Consumer
 }
 
 func (s *sqlConsumerService) Delete(ctx context.Context, id string) *errors.ServiceError {
+	consumer, err := s.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	_, e := s.resourceDao.FirstByConsumerName(ctx, consumer.Name)
+	if e == nil {
+		return errors.Forbidden("Resources associated with the consumer: %s", consumer.Name)
+	}
+
+	if e != gorm.ErrRecordNotFound {
+		return handleGetError("Resource", "consumer_name", consumer.Name, e)
+	}
+
+	// e is record not found
 	if err := s.consumerDao.Delete(ctx, id); err != nil {
 		return handleDeleteError("Consumer", errors.GeneralError("Unable to delete consumer: %s", err))
 	}

--- a/pkg/services/util.go
+++ b/pkg/services/util.go
@@ -48,6 +48,9 @@ func handleUpdateError(resourceType string, err error) *errors.ServiceError {
 }
 
 func handleDeleteError(resourceType string, err error) *errors.ServiceError {
+	if strings.Contains(err.Error(), "violates foreign key constraint") {
+		return errors.Forbidden("Unable to delete %s: %s", resourceType, err)
+	}
 	return errors.GeneralError("Unable to delete %s: %s", resourceType, err.Error())
 }
 

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -11,25 +12,42 @@ import (
 
 // go test -v ./test/e2e/pkg -args -api-server=$api_server -consumer-name=$consumer_name -consumer-kubeconfig=$consumer_kubeconfig -ginkgo.focus "Consumer"
 var _ = Describe("Consumer", Ordered, func() {
-	var testConsumerName string
-	var testConsumerID string
+	var consumer openapi.Consumer
+	var resourceConsumer openapi.Consumer
+	var resource openapi.Resource
 	BeforeAll(func() {
-		testConsumerName = "test-consumer"
+		consumer = openapi.Consumer{Name: openapi.PtrString("linda")}
+		resourceConsumer = openapi.Consumer{Name: openapi.PtrString("susan")}
+		resource = helper.NewAPIResource(*resourceConsumer.Name, 1)
 	})
 
 	Context("Consumer CRUD Tests", func() {
 		It("create consumer", func() {
-			consumer := openapi.Consumer{Name: &testConsumerName}
+			// create a consumser without resource
 			created, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersPost(ctx).Consumer(consumer).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 			Expect(*created.Id).NotTo(BeEmpty())
-			testConsumerID = *created.Id
+			consumer = *created
 
-			got, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, testConsumerID).Execute()
+			got, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumer.Id).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(got).NotTo(BeNil())
+
+			// create a consumser associates with resource
+			created, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersPost(ctx).Consumer(resourceConsumer).Execute()
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			Expect(*created.Id).NotTo(BeEmpty())
+			resourceConsumer = *created
+
+			res, resp, err := apiClient.DefaultApi.ApiMaestroV1ResourcesPost(ctx).Resource(resource).Execute()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			Expect(*res.Id).ShouldNot(BeEmpty())
+			Expect(*res.Version).To(Equal(int32(1)))
+			resource = *res
 		})
 
 		It("list consumer", func() {
@@ -41,7 +59,8 @@ var _ = Describe("Consumer", Ordered, func() {
 
 			got := false
 			for _, c := range consumerList.Items {
-				if *c.Name == testConsumerName {
+				fmt.Println("got the consumer:", *c.Name, *c.Id)
+				if *c.Name == *consumer.Name {
 					got = true
 				}
 			}
@@ -50,14 +69,14 @@ var _ = Describe("Consumer", Ordered, func() {
 
 		It("patch consumer", func() {
 			labels := &map[string]string{"hello": "world"}
-			patched, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdPatch(ctx, testConsumerID).
+			patched, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdPatch(ctx, *consumer.Id).
 				ConsumerPatchRequest(openapi.ConsumerPatchRequest{Labels: labels}).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			_, ok := patched.GetLabelsOk()
 			Expect(ok).To(BeTrue())
 
-			got, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, testConsumerID).Execute()
+			got, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumer.Id).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(got).NotTo(BeNil())
@@ -66,7 +85,30 @@ var _ = Describe("Consumer", Ordered, func() {
 		})
 
 		AfterAll(func() {
-			// TODO: add the consumer deletion
+			// delete the consumer
+			resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumer.Id).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumer.Id).Execute()
+			Expect(err.Error()).To(ContainSubstring("Not Found"))
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			// delete the consumer associated with resource
+			// 403 forbid deletion
+			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *resourceConsumer.Id).Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+
+			// delete the resource
+			resp, err = apiClient.DefaultApi.ApiMaestroV1ResourcesIdDelete(ctx, *resource.Id).Execute()
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+			// delete the consumer
+			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumer.Id).Execute()
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 		})
 	})
 })

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(eq).To(BeTrue())
 		})
 
-		AfterAll(func() {
+		It("delete consumer", func() {
 			// delete the consumer
 			resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumer.Id).Execute()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// delete the consumer
-			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumer.Id).Execute()
+			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *resourceConsumer.Id).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 		})

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"fmt"
 	"net/http"
 	"reflect"
 
@@ -23,7 +22,7 @@ var _ = Describe("Consumer", Ordered, func() {
 
 	Context("Consumer CRUD Tests", func() {
 		It("create consumer", func() {
-			// create a consumser without resource
+			// create a consumer without resource
 			created, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersPost(ctx).Consumer(consumer).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
@@ -35,7 +34,7 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(got).NotTo(BeNil())
 
-			// create a consumser associates with resource
+			// create a consumer associates with resource
 			created, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersPost(ctx).Consumer(resourceConsumer).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
@@ -59,7 +58,6 @@ var _ = Describe("Consumer", Ordered, func() {
 
 			got := false
 			for _, c := range consumerList.Items {
-				fmt.Println("got the consumer:", *c.Name, *c.Id)
 				if *c.Name == *consumer.Name {
 					got = true
 				}
@@ -95,17 +93,16 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
 			// delete the consumer associated with resource
-			// 403 forbid deletion
 			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *resourceConsumer.Id).Execute()
 			Expect(err).To(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden)) // 403 forbid deletion
 
 			// delete the resource
 			resp, err = apiClient.DefaultApi.ApiMaestroV1ResourcesIdDelete(ctx, *resource.Id).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-			// delete the consumer
+			// delete the associated consumer
 			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *resourceConsumer.Id).Execute()
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -87,7 +87,6 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-			// check the consumer is deleted
 			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumer.Id).Execute()
 			Expect(err.Error()).To(ContainSubstring("Not Found"))
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))

--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -102,10 +102,11 @@ var _ = Describe("Consumer", Ordered, func() {
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-			// delete the associated consumer
+			// only permanently delete the resources, the consumer can be deleted
+			// deleting resource still block the consumer deletion
 			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *resourceConsumer.Id).Execute()
-			Expect(err).To(Succeed())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			Expect(err).To(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden)) // 403 forbid deletion
 		})
 	})
 })

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -198,15 +198,15 @@ func TestConsumerDeleteForbidden(t *testing.T) {
 	Expect(err).To(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 
-	// delete the resource
+	// delete the resource(marked as deleted)
 	resp, err = client.DefaultApi.ApiMaestroV1ResourcesIdDelete(ctx, *resource.Id).Execute()
 	Expect(err).To(Succeed())
 	Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-	// delete the consumer
+	// still forbid deletion for the deleting resource
 	resp, err = client.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumer.Id).Execute()
-	Expect(err).To(Succeed())
-	Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+	Expect(err).To(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 }
 
 func TestConsumerPaging(t *testing.T) {

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -271,7 +271,7 @@ func TestConsumerDeleting(t *testing.T) {
 
 	wg.Wait()
 
-	// verify the deleted consumer:
+	// verify the deleting consumer:
 	// 1. success -> no resources is associated with it
 	// 2. failed -> resources are associated with it
 	for i := 0; i < consumerNum; i++ {
@@ -299,8 +299,8 @@ func TestConsumerDeleting(t *testing.T) {
 	}
 	close(consumerChan)
 
-	// verify the resources:
-	// 1. success: consumer is exist
+	// verify the creating resources:
+	// 1. success: consumer exists
 	// 2. failed: consumer is deleted
 	for i := 0; i < consumerNum*resourceNum; i++ {
 		result := <-resourceChan

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -288,16 +288,14 @@ func TestConsumerDeleting(t *testing.T) {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		Expect(err).To(Succeed())
 
-		if consumerStatusCode == http.StatusForbidden {
-			// at least one resource on the consumer
-			fmt.Println("consumer", consumerName, "associated resources", len(resourceList.Items))
-			Expect(resourceList.Items).NotTo(BeEmpty(), resourceList.Items)
-		} else if consumerStatusCode == http.StatusNoContent {
+		if consumerStatusCode == http.StatusNoContent {
 			// no resource is assocaited with the consumer
 			fmt.Println("consumer", consumerName, "deleted successfully!")
 			Expect(resourceList.Items).To(BeEmpty())
 		} else {
-			fmt.Println("unexpected consumer statusCode", consumerStatusCode)
+			// at least one resource on the consumer, the statusCode should be 403 or 500
+			fmt.Printf("failed to delete consumer(%s), associated with resource(%d), statusCode: %d \n", consumerName, len(resourceList.Items), consumerStatusCode)
+			Expect(resourceList.Items).NotTo(BeEmpty(), resourceList.Items)
 		}
 	}
 	close(consumerChan)
@@ -321,6 +319,7 @@ func TestConsumerDeleting(t *testing.T) {
 			Expect(*consumer.Id).To(Equal(resourceConsumerId))
 			Expect(*consumer.Name).To(Equal(resourceConsumerName))
 		} else {
+			fmt.Printf("failed to create resource on consumer(%s), statusCode: %d, err: %v \n", resourceConsumerName, resourceStatusCode, result.err)
 			Expect(err.Error()).To(ContainSubstring("Not Found"))
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		}

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -210,7 +210,6 @@ func TestConsumerDeleteForbidden(t *testing.T) {
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 }
 
-// TestConsumerDeleting is to test creating resources when delete the consumer
 func TestConsumerDeleting(t *testing.T) {
 	h, client := test.RegisterIntegration(t)
 	account := h.NewRandAccount()

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -282,6 +282,7 @@ func TestConsumerDeleting(t *testing.T) {
 
 		consumerName := result.consumerName
 		consumerStatusCode := result.resp.StatusCode
+		consumerErr := result.err
 
 		search := fmt.Sprintf("consumer_name = '%s'", consumerName)
 		resourceList, resp, err := client.DefaultApi.ApiMaestroV1ResourcesGet(ctx).Search(search).Execute()
@@ -294,7 +295,7 @@ func TestConsumerDeleting(t *testing.T) {
 			Expect(resourceList.Items).To(BeEmpty())
 		} else {
 			// at least one resource on the consumer, the statusCode should be 403 or 500
-			fmt.Printf("failed to delete consumer(%s), associated with resource(%d), statusCode: %d \n", consumerName, len(resourceList.Items), consumerStatusCode)
+			fmt.Printf("failed to delete consumer(%s), associated with resource(%d), statusCode: %d, err: %v \n", consumerName, len(resourceList.Items), consumerStatusCode, consumerErr)
 			Expect(resourceList.Items).NotTo(BeEmpty(), resourceList.Items)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Note: 

Delete will remove the consumer from the storage:
1. Perform a hard delete on the consumer, the resource creation will be blocked by it.
2. Forbid consumer deletion if there are associated resources(include the marked as deleted resources).

TODO: Additional deletion options or strategies might be added in the future.