### PR TITLE
fix creation and deletion timestamp for work metadata.

### DIFF
--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -183,11 +183,10 @@ func (svr *GRPCServer) Publish(ctx context.Context, pubReq *pbv1.PublishRequest)
 		var deletionTimestamp time.Time
 		evtExtensions := evt.Context.GetExtensions()
 		if _, ok := evtExtensions[codec.ExtensionWorkMeta]; ok {
-			if deletionTimestampValue, exists := evtExtensions[types.ExtensionDeletionTimestamp]; exists {
-				deletionTimestamp, err = cetypes.ToTime(deletionTimestampValue)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert deletion timestamp %v to time.Time: %v", deletionTimestampValue, err)
-				}
+			if _, exists := evtExtensions[types.ExtensionDeletionTimestamp]; exists {
+				// Use the server-generated deletion timestamp from the Maestro server instead of the source client's timestamp
+				// to account for potential timezone discrepancies between the source client and the Maestro server.
+				deletionTimestamp = time.Now()
 			}
 		}
 		sErr := svr.resourceService.MarkAsDeleting(ctx, res.ID, deletionTimestamp)

--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"time"
@@ -9,12 +10,14 @@ import (
 	ce "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	cetypes "github.com/cloudevents/sdk-go/v2/types"
+	cloudeventstypes "github.com/cloudevents/sdk-go/v2/types"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/emptypb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
 	grpcprotocol "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
@@ -121,18 +124,41 @@ func (svr *GRPCServer) Publish(ctx context.Context, pubReq *pbv1.PublishRequest)
 		return &emptypb.Empty{}, nil
 	}
 
-	res, err := decode(eventType.CloudEventsDataType, evt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
-	}
-
+	var res *api.Resource
 	switch eventType.Action {
 	case common.CreateRequestAction:
+		// set creation timestamp in work metadata
+		creationTimestamp := time.Now()
+		if workMeta, ok := evt.Extensions()[codec.ExtensionWorkMeta]; ok {
+			metaJSON, err := cloudeventstypes.ToString(workMeta)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert work meta extension to json: %v", err)
+			}
+			metaObj := metav1.ObjectMeta{}
+			if err := json.Unmarshal([]byte(metaJSON), &metaObj); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal work meta extension: %v", err)
+			}
+			metaObj.CreationTimestamp = metav1.Time{Time: creationTimestamp}
+			metaJSONBytes, err := json.Marshal(metaObj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal work meta extension: %v", err)
+			}
+			evt.SetExtension(codec.ExtensionWorkMeta, string(metaJSONBytes))
+		}
+		res, err = decode(eventType.CloudEventsDataType, evt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
+		}
+		res.Meta.CreatedAt = creationTimestamp
 		_, err := svr.resourceService.Create(ctx, res)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource: %v", err)
 		}
 	case common.UpdateRequestAction:
+		res, err = decode(eventType.CloudEventsDataType, evt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
+		}
 		if res.Type == api.ResourceTypeBundle {
 			found, err := svr.resourceService.Get(ctx, res.ID)
 			if err != nil {
@@ -150,8 +176,22 @@ func (svr *GRPCServer) Publish(ctx context.Context, pubReq *pbv1.PublishRequest)
 			return nil, fmt.Errorf("failed to update resource: %v", err)
 		}
 	case common.DeleteRequestAction:
-		err := svr.resourceService.MarkAsDeleting(ctx, res.ID)
+		res, err = decode(eventType.CloudEventsDataType, evt)
 		if err != nil {
+			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
+		}
+		var deletionTimestamp time.Time
+		evtExtensions := evt.Context.GetExtensions()
+		if _, ok := evtExtensions[codec.ExtensionWorkMeta]; ok {
+			if deletionTimestampValue, exists := evtExtensions[types.ExtensionDeletionTimestamp]; exists {
+				deletionTimestamp, err = cetypes.ToTime(deletionTimestampValue)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert deletion timestamp %v to time.Time: %v", deletionTimestampValue, err)
+				}
+			}
+		}
+		sErr := svr.resourceService.MarkAsDeleting(ctx, res.ID, deletionTimestamp)
+		if sErr != nil {
 			return nil, fmt.Errorf("failed to update resource: %v", err)
 		}
 	default:
@@ -289,11 +329,6 @@ func encode(resource *api.Resource) (*ce.Event, error) {
 		specEvt, err := api.JSONMAPToCloudEvent(resource.Payload)
 		if err != nil {
 			return nil, err
-		}
-
-		// set work meta back from spec event
-		if workMeta, ok := specEvt.Extensions()[codec.ExtensionWorkMeta]; ok {
-			evt.SetExtension(codec.ExtensionWorkMeta, workMeta)
 		}
 
 		// set work spec back from spec event

--- a/pkg/api/resource_bundle_types.go
+++ b/pkg/api/resource_bundle_types.go
@@ -9,6 +9,7 @@ import (
 
 	cetypes "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	workpayload "open-cluster-management.io/sdk-go/pkg/cloudevents/work/payload"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/source/codec"
 )
 
 type ResourceBundleStatus struct {
@@ -31,7 +32,7 @@ func DecodeManifestBundle(manifest datatypes.JSONMap) (map[string]any, *workpayl
 
 	metaData := map[string]any{}
 	extensions := evt.Extensions()
-	if meta, ok := extensions["metadata"]; ok {
+	if meta, ok := extensions[codec.ExtensionWorkMeta]; ok {
 		metaJson, err := cloudeventstypes.ToString(meta)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/handlers/resource.go
+++ b/pkg/handlers/resource.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -172,7 +173,7 @@ func (h resourceHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			err := h.resource.MarkAsDeleting(ctx, id)
+			err := h.resource.MarkAsDeleting(ctx, id, time.Time{})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
fix: https://github.com/openshift-online/maestro/issues/158

by setting the CreationTimestamp and DeletionTimestamp when publishing the manifest work and saving them to the database.

when deletion is triggered, the resource-bundles API returns:
```
{
  "items": [
    {
      "consumer_name": "fed01f98-4d6e-4f21-9d8a-fb70831dc987",
      "created_at": "2024-07-11T08:12:19.362465Z",
      "delete_option": {},
      "deleted_at": "2024-07-11T08:12:44.400699Z",
      "href": "/api/maestro/v1/resource-bundles/39fb0720-6487-582d-ba1f-1df6be62d427",
      "id": "39fb0720-6487-582d-ba1f-1df6be62d427",
      "kind": "ResourceBundle",
      "manifest_configs": [],
      "manifests": [
        {
          "apiVersion": "v1",
          "data": {
            "test": "wxclm"
          },
          "kind": "ConfigMap",
          "metadata": {
            "name": "work-k6lbc",
            "namespace": "default"
          }
        }
      ],
      "metadata": {
        "annotations": {
          "work.annotations": "example"
        },
        "creationTimestamp": "2024-07-11T08:12:19Z",
        "deletionTimestamp": "2024-07-11T08:12:44Z",
        "labels": {
          "work.label": "example"
        },
        "name": "work-k6lbc",
        "namespace": "fed01f98-4d6e-4f21-9d8a-fb70831dc987",
        "resourceVersion": "1",
        "uid": "39fb0720-6487-582d-ba1f-1df6be62d427"
      },
```