### PR TITLE
handle creationTimestamp and deletionTimestamp in work metadata.

### DIFF
--- a/cmd/maestro/environments/service_types.go
+++ b/cmd/maestro/environments/service_types.go
@@ -14,6 +14,7 @@ func NewResourceServiceLocator(env *Env) ResourceServiceLocator {
 			db.NewAdvisoryLockFactory(env.Database.SessionFactory),
 			dao.NewResourceDao(&env.Database.SessionFactory),
 			env.Services.Events(),
+			env.Services.Generic(),
 		)
 	}
 }

--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"time"
@@ -10,14 +9,12 @@ import (
 	ce "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	cetypes "github.com/cloudevents/sdk-go/v2/types"
-	cloudeventstypes "github.com/cloudevents/sdk-go/v2/types"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/emptypb"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
 	grpcprotocol "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
@@ -124,41 +121,18 @@ func (svr *GRPCServer) Publish(ctx context.Context, pubReq *pbv1.PublishRequest)
 		return &emptypb.Empty{}, nil
 	}
 
-	var res *api.Resource
+	res, err := decode(eventType.CloudEventsDataType, evt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
+	}
+
 	switch eventType.Action {
 	case common.CreateRequestAction:
-		// set creation timestamp in work metadata
-		creationTimestamp := time.Now()
-		if workMeta, ok := evt.Extensions()[codec.ExtensionWorkMeta]; ok {
-			metaJSON, err := cloudeventstypes.ToString(workMeta)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert work meta extension to json: %v", err)
-			}
-			metaObj := metav1.ObjectMeta{}
-			if err := json.Unmarshal([]byte(metaJSON), &metaObj); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal work meta extension: %v", err)
-			}
-			metaObj.CreationTimestamp = metav1.Time{Time: creationTimestamp}
-			metaJSONBytes, err := json.Marshal(metaObj)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal work meta extension: %v", err)
-			}
-			evt.SetExtension(codec.ExtensionWorkMeta, string(metaJSONBytes))
-		}
-		res, err = decode(eventType.CloudEventsDataType, evt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
-		}
-		res.Meta.CreatedAt = creationTimestamp
 		_, err := svr.resourceService.Create(ctx, res)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource: %v", err)
 		}
 	case common.UpdateRequestAction:
-		res, err = decode(eventType.CloudEventsDataType, evt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
-		}
 		if res.Type == api.ResourceTypeBundle {
 			found, err := svr.resourceService.Get(ctx, res.ID)
 			if err != nil {
@@ -176,22 +150,9 @@ func (svr *GRPCServer) Publish(ctx context.Context, pubReq *pbv1.PublishRequest)
 			return nil, fmt.Errorf("failed to update resource: %v", err)
 		}
 	case common.DeleteRequestAction:
-		res, err = decode(eventType.CloudEventsDataType, evt)
+		err := svr.resourceService.MarkAsDeleting(ctx, res.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode cloudevent: %v", err)
-		}
-		var deletionTimestamp time.Time
-		evtExtensions := evt.Context.GetExtensions()
-		if _, ok := evtExtensions[codec.ExtensionWorkMeta]; ok {
-			if _, exists := evtExtensions[types.ExtensionDeletionTimestamp]; exists {
-				// Use the server-generated deletion timestamp from the Maestro server instead of the source client's timestamp
-				// to account for potential timezone discrepancies between the source client and the Maestro server.
-				deletionTimestamp = time.Now()
-			}
-		}
-		sErr := svr.resourceService.MarkAsDeleting(ctx, res.ID, deletionTimestamp)
-		if sErr != nil {
-			return nil, fmt.Errorf("failed to update resource: %v", err)
+			return nil, fmt.Errorf("failed to delete resource: %v", err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported action %s", eventType.Action)

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -30,17 +30,6 @@ func (d *resourceDaoMock) Get(ctx context.Context, id string) (*api.Resource, er
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (d *resourceDaoMock) GetBundle(ctx context.Context, id string) (*api.Resource, error) {
-	for _, resource := range d.resources {
-		if resource.ID == id {
-			if resource.Type == api.ResourceTypeBundle {
-				return resource, nil
-			}
-		}
-	}
-	return nil, gorm.ErrRecordNotFound
-}
-
 func (d *resourceDaoMock) Create(ctx context.Context, resource *api.Resource) (*api.Resource, error) {
 	d.resources = append(d.resources, resource)
 	return resource, nil

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -11,7 +11,6 @@ import (
 
 type ResourceDao interface {
 	Get(ctx context.Context, id string) (*api.Resource, error)
-	GetBundle(ctx context.Context, id string) (*api.Resource, error)
 	Create(ctx context.Context, resource *api.Resource) (*api.Resource, error)
 	Update(ctx context.Context, resource *api.Resource) (*api.Resource, error)
 	Delete(ctx context.Context, id string, unscoped bool) error
@@ -36,15 +35,6 @@ func (d *sqlResourceDao) Get(ctx context.Context, id string) (*api.Resource, err
 	g2 := (*d.sessionFactory).New(ctx)
 	var resource api.Resource
 	if err := g2.Unscoped().Take(&resource, "id = ?", id).Error; err != nil {
-		return nil, err
-	}
-	return &resource, nil
-}
-
-func (d *sqlResourceDao) GetBundle(ctx context.Context, id string) (*api.Resource, error) {
-	g2 := (*d.sessionFactory).New(ctx)
-	var resource api.Resource
-	if err := g2.Unscoped().Take(&resource, "id = ? AND type = ?", id, api.ResourceTypeBundle).Error; err != nil {
 		return nil, err
 	}
 	return &resource, nil

--- a/pkg/handlers/resource.go
+++ b/pkg/handlers/resource.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -173,7 +172,7 @@ func (h resourceHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			err := h.resource.MarkAsDeleting(ctx, id, time.Time{})
+			err := h.resource.MarkAsDeleting(ctx, id)
 			if err != nil {
 				return nil, err
 			}
@@ -188,7 +187,7 @@ func (h resourceHandler) GetBundle(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			resource, serviceErr := h.resource.GetBundle(ctx, id)
+			resource, serviceErr := h.resource.Get(ctx, id)
 			if serviceErr != nil {
 				return nil, serviceErr
 			}
@@ -216,7 +215,7 @@ func (h resourceHandler) ListBundle(w http.ResponseWriter, r *http.Request) {
 				listArgs.Search = fmt.Sprintf("%s and type='%s'", listArgs.Search, api.ResourceTypeBundle)
 			}
 			var resources []api.Resource
-			paging, serviceErr := h.generic.List(ctx, "username", listArgs, &resources)
+			paging, serviceErr := h.resource.ListWithArgs(ctx, "username", listArgs, &resources)
 			if serviceErr != nil {
 				return nil, serviceErr
 			}

--- a/pkg/services/resource_test.go
+++ b/pkg/services/resource_test.go
@@ -16,7 +16,8 @@ func TestResourceFindByConsumerID(t *testing.T) {
 
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events)
+
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
 
 	const Fukuisaurus = "b288a9da-8bfe-4c82-94cc-2b48e773fc46"
 	const Seismosaurus = "e3eb7db1-b124-4a4d-8bb6-cc779c01b402"
@@ -53,7 +54,7 @@ func TestCreateInvalidResource(t *testing.T) {
 
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events)
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
 
 	resource := &api.Resource{ConsumerName: "invalidation", Payload: newPayload(t, "{}")}
 

--- a/test/e2e/pkg/sourceclient_test.go
+++ b/test/e2e/pkg/sourceclient_test.go
@@ -431,19 +431,19 @@ func AssertWatchResult(result *WatchedResult) error {
 	hasDeletedWork := false
 
 	for _, watchedWork := range result.WatchedWorks {
-		if strings.HasPrefix(watchedWork.Name, "init-work-a") {
+		if strings.HasPrefix(watchedWork.Name, "init-work-a") && !watchedWork.CreationTimestamp.IsZero() {
 			hasFirstInitWork = true
 		}
 
-		if strings.HasPrefix(watchedWork.Name, "init-work-b") {
+		if strings.HasPrefix(watchedWork.Name, "init-work-b") && !watchedWork.CreationTimestamp.IsZero() {
 			hasSecondInitWork = true
 		}
 
-		if strings.HasPrefix(watchedWork.Name, "work-") {
+		if strings.HasPrefix(watchedWork.Name, "work-") && !watchedWork.CreationTimestamp.IsZero() {
 			hasWork = true
 		}
 
-		if meta.IsStatusConditionTrue(watchedWork.Status.Conditions, common.ManifestsDeleted) {
+		if meta.IsStatusConditionTrue(watchedWork.Status.Conditions, common.ManifestsDeleted) && !watchedWork.DeletionTimestamp.IsZero() {
 			hasDeletedWork = true
 		}
 	}


### PR DESCRIPTION
This PR reverts some changes from https://github.com/openshift-online/maestro/pull/159.
It addresses issues with creationTimestamp and deletionTimestamp in work metadata by populating them from resource createdAt and deletedAt when retrieving the resource.