### PR TITLE
avoid do full list on the client part

### DIFF
--- a/examples/manifestworkclient/README.md
+++ b/examples/manifestworkclient/README.md
@@ -1,6 +1,6 @@
 # gRPC Source ManifestWork Client
 
-This example shows how to build a source ManifestWork client with Maestro gRPC service and watch/create/get/update/delete works by this client.
+This example shows how to build a source ManifestWork client with Maestro gRPC service and watch/get/list/create/patch/delete works by this client.
 
 ## Build the client
 
@@ -18,7 +18,47 @@ if err != nil {
 		log.Fatal(err)
 }
 
-// watch/create/patch/get/delete/list by workClient
+// watch/get/list/create/patch/delete by workClient
+```
+
+## List works
+
+The `List` of the gRPC source ManifestWork client supports to paging list works, this will help to list the works when there are a lot of works in the maestro sever, e.g.
+
+```golang
+
+workClient, err := ...
+
+// There are 2500 works in the maestro, we will list these works with paging
+
+// First list: this will return 1000 (this is controlled by `ListOptions.Limit`) works and
+// with a next page (2) in the `workList.ListMeta.Continue`
+workList, err := workClient.ManifestWorks(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		Limit: 1000
+})
+if err != nil {
+  log.Fatal(err)
+}
+
+// Second list: we list works with last returned `ListMeta.Continue`, this will also return
+// 1000 works and with a next page (3) in the `workList.ListMeta.Continue`
+workList, err = workClient.ManifestWorks(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		Limit: 1000,
+    Continue: workList.ListMeta.Continue,
+})
+if err != nil {
+  log.Fatal(err)
+}
+
+// Third list: we also list works with last returned `ListMeta.Continue`, this will return
+// all remaining works (500) and the `workList.ListMeta.Continue` will be empty
+workList, err = workClient.ManifestWorks(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		Limit: 1000,
+    Continue: workList.ListMeta.Continue,
+})
+if err != nil {
+  log.Fatal(err)
+}
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	open-cluster-management.io/api v0.14.1-0.20240627145512-bd6f2229b53c
 	open-cluster-management.io/ocm v0.13.1-0.20240618054845-e2a7b9e78b33
-	open-cluster-management.io/sdk-go v0.14.1-0.20240717021054-955108a181ee
+	open-cluster-management.io/sdk-go v0.14.1-0.20240806021439-bf354ff3847f
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -827,6 +827,8 @@ open-cluster-management.io/ocm v0.13.1-0.20240618054845-e2a7b9e78b33 h1:7uPjyn1x
 open-cluster-management.io/ocm v0.13.1-0.20240618054845-e2a7b9e78b33/go.mod h1:KzUwhPZAg6Wq+4xRu10fVVpqNADyz5CtRW4ziqIC2z4=
 open-cluster-management.io/sdk-go v0.14.1-0.20240717021054-955108a181ee h1:aQ4AoR8SKz/byOyZbbYC9Tbp4VCtRHje8uHbn438o84=
 open-cluster-management.io/sdk-go v0.14.1-0.20240717021054-955108a181ee/go.mod h1:xFmN3Db5nN68oLGnstmIRv4us8HJCdXFnBNMXVp0jWY=
+open-cluster-management.io/sdk-go v0.14.1-0.20240806021439-bf354ff3847f h1:8yQ8uFemyM/dI4nMo8pVOmEiIn156SkN9qpnLf8UOcI=
+open-cluster-management.io/sdk-go v0.14.1-0.20240806021439-bf354ff3847f/go.mod h1:xFmN3Db5nN68oLGnstmIRv4us8HJCdXFnBNMXVp0jWY=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 h1:/U5vjBbQn3RChhv7P11uhYvCSm5G2GaIi5AIGBS6r4c=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0/go.mod h1:z7+wmGM2dfIiLRfrC6jb5kV2Mq/sK1ZP303cxzkV5Y4=
 sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHvm5BZw=

--- a/pkg/client/cloudevents/grpcsource/mock/maestro.go
+++ b/pkg/client/cloudevents/grpcsource/mock/maestro.go
@@ -1,0 +1,94 @@
+package mock
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"time"
+
+	"github.com/openshift-online/maestro/pkg/api/openapi"
+)
+
+type ResourceBundlesStore struct {
+	items []openapi.ResourceBundle
+}
+
+func (g *ResourceBundlesStore) Get() []openapi.ResourceBundle {
+	return g.items
+}
+
+func (g *ResourceBundlesStore) Set(items []openapi.ResourceBundle) {
+	g.items = items
+}
+
+type MaestroMockServer struct {
+	server *httptest.Server
+}
+
+func NewMaestroMockServer(store *ResourceBundlesStore) *MaestroMockServer {
+	mockServer := &MaestroMockServer{}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			list := &openapi.ResourceBundleList{}
+			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			size, _ := strconv.Atoi(r.URL.Query().Get("size"))
+
+			items := store.Get()
+			index := ((page - 1) * size)
+			for i := 0; i < size; i++ {
+				if index >= len(items) {
+					break
+				}
+				list.Items = append(list.Items, items[index])
+				index = index + 1
+			}
+
+			list.Page = int32(page)
+			list.Total = int32(len(items))
+			list.Size = int32(len(list.Items))
+			data, _ := json.Marshal(list)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	})
+
+	mockServer.server = httptest.NewUnstartedServer(handler)
+	return mockServer
+}
+
+func (m *MaestroMockServer) URL() string {
+	return m.server.URL
+}
+
+func (m *MaestroMockServer) Start() {
+	m.server.Start()
+}
+
+func (m *MaestroMockServer) Stop() {
+	m.server.Close()
+}
+
+func NewMaestroAPIClient(maestroServerAddress string) *openapi.APIClient {
+	cfg := &openapi.Configuration{
+		DefaultHeader: make(map[string]string),
+		UserAgent:     "OpenAPI-Generator/1.0.0/go",
+		Debug:         false,
+		Servers: openapi.ServerConfigurations{
+			{
+				URL:         maestroServerAddress,
+				Description: "current domain",
+			},
+		},
+		OperationServers: map[string]openapi.ServerConfigurations{},
+		HTTPClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+	return openapi.NewAPIClient(cfg)
+}

--- a/pkg/client/cloudevents/grpcsource/pager.go
+++ b/pkg/client/cloudevents/grpcsource/pager.go
@@ -1,0 +1,104 @@
+package grpcsource
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/openshift-online/maestro/pkg/api/openapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// MaxListPageSize is the maximum size of one page, default is 400.
+// NOTE: This should be reset carefully, when increasing this value, both maestro server's memory limit
+// and the page size of resources need to be considered, if a bigger value is used, it might lead to
+// maestro server OOM.
+var MaxListPageSize int32 = 400
+
+// pageList assists client code in breaking large list queries into multiple smaller chunks of PageSize or smaller.
+func pageList(client *openapi.APIClient, search string, opts metav1.ListOptions) (*openapi.ResourceBundleList, string, error) {
+	items := []openapi.ResourceBundle{}
+
+	page, err := page(opts)
+	if err != nil {
+		return nil, "", err
+	}
+
+	limit := opts.Limit
+	if limit < 0 {
+		return nil, "", fmt.Errorf("limit cannot be less than 0")
+	}
+
+	var total int32 = 0
+	nextPage := ""
+	pageSize := pageSize(int32(limit))
+	offset := (page - 1) * pageSize
+	for {
+		klog.V(4).Infof("list works with search=%s, page=%d, size=%d", search, page, pageSize)
+		rbs, _, err := client.DefaultApi.ApiMaestroV1ResourceBundlesGet(context.Background()).
+			Search(search).
+			Page(page).
+			Size(pageSize).
+			Execute()
+		if err != nil {
+			return nil, "", err
+		}
+		klog.V(4).Infof("listed works total=%d, page=%d, size=%d", rbs.Total, rbs.Page, rbs.Size)
+
+		items = append(items, rbs.Items...)
+		total = rbs.Size + total
+		page = page + 1
+
+		if rbs.Size < pageSize {
+			// reaches the last page, stop list
+			break
+		}
+
+		if limit == 0 {
+			// no limit, continue to list the rest of items
+			continue
+		}
+
+		if total == int32(limit) {
+			// reaches the limit, stop list
+			if (total + offset) < rbs.Total {
+				// the listed items reach the limit size, but there are still items left
+				nextPage = fmt.Sprintf("%d", page)
+			}
+
+			break
+		}
+	}
+
+	return &openapi.ResourceBundleList{Items: items}, nextPage, nil
+}
+
+func page(opts metav1.ListOptions) (int32, error) {
+	if len(opts.Continue) == 0 {
+		return 1, nil
+	}
+
+	page, err := strconv.Atoi(opts.Continue)
+	if err != nil {
+		return 0, fmt.Errorf("a page number is required, %v", err)
+	}
+
+	if page < 0 {
+		return 0, fmt.Errorf("an invalid page number %d", page)
+	}
+
+	return int32(page), nil
+}
+
+func pageSize(limit int32) int32 {
+	if limit > MaxListPageSize {
+		return MaxListPageSize
+	}
+
+	if limit == 0 {
+		return MaxListPageSize
+	}
+
+	return limit
+}

--- a/pkg/client/cloudevents/grpcsource/pager_test.go
+++ b/pkg/client/cloudevents/grpcsource/pager_test.go
@@ -1,0 +1,169 @@
+package grpcsource
+
+import (
+	"testing"
+
+	"github.com/openshift-online/maestro/pkg/api/openapi"
+	"github.com/openshift-online/maestro/pkg/client/cloudevents/grpcsource/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPageList(t *testing.T) {
+	getter := &mock.ResourceBundlesStore{}
+	maestroServer := mock.NewMaestroMockServer(getter)
+	maestroServer.Start()
+	defer maestroServer.Stop()
+
+	client := mock.NewMaestroAPIClient(maestroServer.URL())
+	cases := []struct {
+		name             string
+		resourceBundles  []openapi.ResourceBundle
+		listOpts         metav1.ListOptions
+		expectedItemsLen int
+		expectedNext     string
+	}{
+		{
+			name:             "no items",
+			resourceBundles:  resourceBundles(0),
+			listOpts:         metav1.ListOptions{},
+			expectedItemsLen: 0,
+			expectedNext:     "",
+		},
+		{
+			name:             "list all items (items < MaxListPageSize)",
+			resourceBundles:  resourceBundles(200),
+			listOpts:         metav1.ListOptions{},
+			expectedItemsLen: 200,
+			expectedNext:     "",
+		},
+		{
+			name:             "list all items (items = MaxListPageSize)",
+			resourceBundles:  resourceBundles(400),
+			listOpts:         metav1.ListOptions{},
+			expectedItemsLen: 400,
+			expectedNext:     "",
+		},
+		{
+			name:             "list all items (items > MaxListPageSize)",
+			resourceBundles:  resourceBundles(429),
+			listOpts:         metav1.ListOptions{},
+			expectedItemsLen: 429,
+			expectedNext:     "",
+		},
+		{
+			name:            "list items (limit > total items)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit: 500,
+			},
+			expectedItemsLen: 429,
+			expectedNext:     "",
+		},
+		{
+			name:            "list items (limit < total items)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit: 400,
+			},
+			expectedItemsLen: 400,
+			expectedNext:     "2",
+		},
+		{
+			name:            "list items (limit < total items)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit: 40,
+			},
+			expectedItemsLen: 40,
+			expectedNext:     "2",
+		},
+		{
+			name:            "list items with continue (from last page - 1)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit:    100,
+				Continue: "4",
+			},
+			expectedItemsLen: 100,
+			expectedNext:     "5",
+		},
+		{
+			name:            "list items with continue (from page last page)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit:    100,
+				Continue: "5",
+			},
+			expectedItemsLen: 29,
+			expectedNext:     "",
+		},
+		{
+			name:            "list items with continue (from page last page + 1)",
+			resourceBundles: resourceBundles(429),
+			listOpts: metav1.ListOptions{
+				Limit:    100,
+				Continue: "6",
+			},
+			expectedItemsLen: 0,
+			expectedNext:     "",
+		},
+		{
+			name:            "list items with continue and max limit",
+			resourceBundles: resourceBundles(1229),
+			listOpts: metav1.ListOptions{
+				Limit:    400,
+				Continue: "3",
+			},
+			expectedItemsLen: 400,
+			expectedNext:     "4",
+		},
+		{
+			name:            "list items with continue and max limit",
+			resourceBundles: resourceBundles(1229),
+			listOpts: metav1.ListOptions{
+				Limit:    400,
+				Continue: "4",
+			},
+			expectedItemsLen: 29,
+			expectedNext:     "",
+		},
+		{
+			name:            "list items with continue and max limit",
+			resourceBundles: resourceBundles(1229),
+			listOpts: metav1.ListOptions{
+				Limit:    400,
+				Continue: "5",
+			},
+			expectedItemsLen: 0,
+			expectedNext:     "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			getter.Set(c.resourceBundles)
+
+			list, next, err := pageList(client, "", c.listOpts)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if len(list.Items) != c.expectedItemsLen {
+				t.Errorf("expected items length %v, but got %v", c.expectedItemsLen, len(list.Items))
+			}
+
+			if next != c.expectedNext {
+				t.Errorf("expected next %v, but got %v", c.expectedNext, next)
+			}
+		})
+
+	}
+}
+
+func resourceBundles(total int) []openapi.ResourceBundle {
+	items := []openapi.ResourceBundle{}
+	for i := 0; i < total; i++ {
+		items = append(items, openapi.ResourceBundle{})
+	}
+	return items
+}


### PR DESCRIPTION
This resolved the problem: when client get a full list from maestro sever, it may lead to the maestro server restart, the root cause is when the maestro server render the list result with the json, the  `json.Marshal` will need a lot of memory, this may lead to maestro server OOM, to avoid this, we should not do a full list query in the client part