### PR TITLE
support grpc auth for grpc server.

### DIFF
--- a/cmd/maestro/environments/framework.go
+++ b/cmd/maestro/environments/framework.go
@@ -206,7 +206,7 @@ func (e *Env) LoadClients() error {
 			glog.Infof("Using Mock GRPC Authorizer")
 			e.Clients.GRPCAuthorizer = grpcauthorizer.NewMockGRPCAuthorizer()
 		} else {
-			kubeConfig, err := clientcmd.BuildConfigFromFlags("", e.Config.GRPCServer.GRPCAuthrizerConfig)
+			kubeConfig, err := clientcmd.BuildConfigFromFlags("", e.Config.GRPCServer.GRPCAuthorizerConfig)
 			if err != nil {
 				glog.Warningf("Unable to create kube client config: %s", err.Error())
 				// fallback to in-cluster config

--- a/cmd/maestro/environments/framework.go
+++ b/cmd/maestro/environments/framework.go
@@ -8,10 +8,14 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/client/cloudevents"
+	"github.com/openshift-online/maestro/pkg/client/grpcauthorizer"
 	"github.com/openshift-online/maestro/pkg/client/ocm"
 	"github.com/openshift-online/maestro/pkg/config"
 	"github.com/openshift-online/maestro/pkg/errors"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
 )
@@ -193,6 +197,31 @@ func (e *Env) LoadClients() error {
 				glog.Errorf("Unable to create CloudEvents Source client: %s", err.Error())
 				return err
 			}
+		}
+	}
+
+	// Create GRPC authorizer based on configuration
+	if e.Config.GRPCServer.EnableGRPCServer {
+		if e.Config.GRPCServer.GRPCAuthNType == "mock" {
+			glog.Infof("Using Mock GRPC Authorizer")
+			e.Clients.GRPCAuthorizer = grpcauthorizer.NewMockGRPCAuthorizer()
+		} else {
+			kubeConfig, err := clientcmd.BuildConfigFromFlags("", e.Config.GRPCServer.GRPCAuthrizerConfig)
+			if err != nil {
+				glog.Warningf("Unable to create kube client config: %s", err.Error())
+				// fallback to in-cluster config
+				kubeConfig, err = rest.InClusterConfig()
+				if err != nil {
+					glog.Errorf("Unable to create kube client config: %s", err.Error())
+					return err
+				}
+			}
+			kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+			if err != nil {
+				glog.Errorf("Unable to create kube client: %s", err.Error())
+				return err
+			}
+			e.Clients.GRPCAuthorizer = grpcauthorizer.NewKubeGRPCAuthorizer(kubeClient)
 		}
 	}
 

--- a/cmd/maestro/environments/types.go
+++ b/cmd/maestro/environments/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift-online/maestro/pkg/auth"
 	"github.com/openshift-online/maestro/pkg/client/cloudevents"
+	"github.com/openshift-online/maestro/pkg/client/grpcauthorizer"
 	"github.com/openshift-online/maestro/pkg/client/ocm"
 	"github.com/openshift-online/maestro/pkg/config"
 	"github.com/openshift-online/maestro/pkg/db"
@@ -57,6 +58,7 @@ type Services struct {
 
 type Clients struct {
 	OCM               *ocm.Client
+	GRPCAuthorizer    grpcauthorizer.GRPCAuthorizer
 	CloudEventsSource cloudevents.SourceClient
 }
 

--- a/cmd/maestro/server/api_server.go
+++ b/cmd/maestro/server/api_server.go
@@ -124,7 +124,6 @@ func NewAPIServer(eventBroadcaster *event.EventBroadcaster) Server {
 		Handler: mainHandler,
 	}
 
-	// TODO: support authn and authz for gRPC
 	if env().Config.GRPCServer.EnableGRPCServer {
 		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventBroadcaster, *env().Config.GRPCServer, env().Clients.GRPCAuthorizer)
 	}

--- a/cmd/maestro/server/api_server.go
+++ b/cmd/maestro/server/api_server.go
@@ -126,7 +126,7 @@ func NewAPIServer(eventBroadcaster *event.EventBroadcaster) Server {
 
 	// TODO: support authn and authz for gRPC
 	if env().Config.GRPCServer.EnableGRPCServer {
-		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventBroadcaster, *env().Config.GRPCServer)
+		s.grpcServer = NewGRPCServer(env().Services.Resources(), eventBroadcaster, *env().Config.GRPCServer, env().Clients.GRPCAuthorizer)
 	}
 	return s
 }

--- a/cmd/maestro/server/auth_interceptor.go
+++ b/cmd/maestro/server/auth_interceptor.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift-online/maestro/pkg/client/grpcauthorizer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// Context key type defined to avoid collisions in other pkgs using context
+// See https://golang.org/pkg/context/#WithValue
+type contextKey string
+
+const (
+	contextUserKey   contextKey = "user"
+	contextGroupsKey contextKey = "groups"
+)
+
+func newContextWithIdentity(ctx context.Context, user string, groups []string) context.Context {
+	ctx = context.WithValue(ctx, contextUserKey, user)
+	return context.WithValue(ctx, contextGroupsKey, groups)
+}
+
+// identityFromCertificate retrieves the user and groups from the client certificate if they are present.
+func identityFromCertificate(ctx context.Context) (string, []string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", nil, status.Error(codes.Unauthenticated, "no peer found")
+	}
+
+	tlsAuth, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", nil, status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
+	}
+
+	if len(tlsAuth.State.VerifiedChains) == 0 || len(tlsAuth.State.VerifiedChains[0]) == 0 {
+		return "", nil, status.Error(codes.Unauthenticated, "could not verify peer certificate")
+	}
+
+	if tlsAuth.State.VerifiedChains[0][0] == nil {
+		return "", nil, status.Error(codes.Unauthenticated, "could not verify peer certificate")
+	}
+
+	user := tlsAuth.State.VerifiedChains[0][0].Subject.CommonName
+	groups := tlsAuth.State.VerifiedChains[0][0].Subject.Organization
+
+	if user == "" {
+		return "", nil, status.Error(codes.Unauthenticated, "could not find user in peer certificate")
+	}
+
+	if len(groups) == 0 {
+		return "", nil, status.Error(codes.Unauthenticated, "could not find group in peer certificate")
+	}
+
+	return user, groups, nil
+}
+
+// identityFromToken retrieves the user and groups from the access token if they are present.
+func identityFromToken(ctx context.Context, grpcAuthorizer grpcauthorizer.GRPCAuthorizer) (string, []string, error) {
+	// Extract the metadata from the context
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", nil, status.Error(codes.InvalidArgument, "missing metadata")
+	}
+
+	// Extract the access token from the metadata
+	authorization, ok := md["authorization"]
+	if !ok || len(authorization) == 0 {
+		return "", nil, status.Error(codes.Unauthenticated, "invalid token")
+	}
+
+	token := strings.TrimPrefix(authorization[0], "Bearer ")
+	// Extract the user and groups from the access token
+	return grpcAuthorizer.TokenReview(ctx, token)
+}
+
+// newAuthUnaryInterceptor creates a unary interceptor that retrieves the user and groups
+// based on the specified authentication type. It supports retrieving from either the access
+// token or the client certificate depending on the provided authNType.
+// The interceptor then adds the retrieved identity information (user and groups) to the
+// context and invokes the provided handler.
+func newAuthUnaryInterceptor(authNType string, authorizer grpcauthorizer.GRPCAuthorizer) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		var user string
+		var groups []string
+		var err error
+		switch authNType {
+		case "token":
+			user, groups, err = identityFromToken(ctx, authorizer)
+			if err != nil {
+				glog.Errorf("unable to get user and groups from token: %v", err)
+				return nil, err
+			}
+		case "mtls":
+			user, groups, err = identityFromCertificate(ctx)
+			if err != nil {
+				glog.Errorf("unable to get user and groups from certificate: %v", err)
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("unsupported authentication type %s", authNType)
+		}
+
+		// call the handler with the new context containing the user and groups
+		return handler(newContextWithIdentity(ctx, user, groups), req)
+	}
+}
+
+// wrappedStream wraps a grpc.ServerStream associated with an incoming RPC, and
+// a custom context containing the user and groups derived from the client certificate
+// specified in the incoming RPC metadata
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedStream) Context() context.Context {
+	return w.ctx
+}
+
+func newWrappedStream(ctx context.Context, s grpc.ServerStream) grpc.ServerStream {
+	return &wrappedStream{s, ctx}
+}
+
+// newAuthStreamInterceptor creates a stream interceptor that retrieves the user and groups
+// based on the specified authentication type. It supports retrieving from either the access
+// token or the client certificate depending on the provided authNType.
+// The interceptor then adds the retrieved identity information (user and groups) to the
+// context and invokes the provided handler.
+func newAuthStreamInterceptor(authNType string, authorizer grpcauthorizer.GRPCAuthorizer) grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		var user string
+		var groups []string
+		var err error
+		switch authNType {
+		case "token":
+			user, groups, err = identityFromToken(ss.Context(), authorizer)
+			if err != nil {
+				glog.Errorf("unable to get user and groups from token: %v", err)
+				return err
+			}
+		case "mtls":
+			user, groups, err = identityFromCertificate(ss.Context())
+			if err != nil {
+				glog.Errorf("unable to get user and groups from certificate: %v", err)
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported authentication Type %s", authNType)
+		}
+
+		return handler(srv, newWrappedStream(newContextWithIdentity(ss.Context(), user, groups), ss))
+	}
+}

--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	ce "github.com/cloudevents/sdk-go/v2"
@@ -16,12 +15,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/peer"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"k8s.io/klog/v2"
 	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
@@ -39,137 +34,6 @@ import (
 	"github.com/openshift-online/maestro/pkg/event"
 	"github.com/openshift-online/maestro/pkg/services"
 )
-
-// Context key type defined to avoid collisions in other pkgs using context
-// See https://golang.org/pkg/context/#WithValue
-type contextKey string
-
-const (
-	contextUserKey   contextKey = "user"
-	contextGroupsKey contextKey = "groups"
-)
-
-func newContextWithIdentity(ctx context.Context, user string, groups []string) context.Context {
-	ctx = context.WithValue(ctx, contextUserKey, user)
-	return context.WithValue(ctx, contextGroupsKey, groups)
-}
-
-// identityFromCertificate retrieves the user and groups from the client certificate if they are present.
-func identityFromCertificate(ctx context.Context) (string, []string, error) {
-	p, ok := peer.FromContext(ctx)
-	if !ok {
-		return "", nil, status.Error(codes.Unauthenticated, "no peer found")
-	}
-
-	tlsAuth, ok := p.AuthInfo.(credentials.TLSInfo)
-	if !ok {
-		return "", nil, status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
-	}
-
-	if len(tlsAuth.State.VerifiedChains) == 0 || len(tlsAuth.State.VerifiedChains[0]) == 0 {
-		return "", nil, status.Error(codes.Unauthenticated, "could not verify peer certificate")
-	}
-
-	if tlsAuth.State.VerifiedChains[0][0] == nil {
-		return "", nil, status.Error(codes.Unauthenticated, "could not verify peer certificate")
-	}
-
-	user := tlsAuth.State.VerifiedChains[0][0].Subject.CommonName
-	groups := tlsAuth.State.VerifiedChains[0][0].Subject.Organization
-
-	if user == "" {
-		return "", nil, status.Error(codes.Unauthenticated, "could not find user in peer certificate")
-	}
-
-	if len(groups) == 0 {
-		return "", nil, status.Error(codes.Unauthenticated, "could not find group in peer certificate")
-	}
-
-	return user, groups, nil
-}
-
-// identityFromToken retrieves the user and groups from the access token if they are present.
-func identityFromToken(ctx context.Context, grpcAuthorizer grpcauthorizer.GRPCAuthorizer) (string, []string, error) {
-	// Extract the metadata from the context
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return "", nil, status.Error(codes.InvalidArgument, "missing metadata")
-	}
-
-	// Extract the access token from the metadata
-	authorization, ok := md["authorization"]
-	if !ok || len(authorization) == 0 {
-		return "", nil, status.Error(codes.Unauthenticated, "invalid token")
-	}
-
-	token := strings.TrimPrefix(authorization[0], "Bearer ")
-	// Extract the user and groups from the access token
-	return grpcAuthorizer.TokenReview(ctx, token)
-}
-
-// newAuthUnaryInterceptor creates a new unary interceptor that looks up the client certificate from the incoming RPC context,
-// retrieves the user and groups from it and creates a new context with the user and groups before invoking the provided handler.
-// otherwise, it falls back retrieving the user and groups from the access token.
-func newAuthUnaryInterceptor(authorizer grpcauthorizer.GRPCAuthorizer) grpc.UnaryServerInterceptor {
-	return func(
-		ctx context.Context,
-		req interface{},
-		info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler,
-	) (interface{}, error) {
-		user, groups, err := identityFromToken(ctx, authorizer)
-		if err != nil {
-			glog.Warningf("unable to get user and groups from token: %v, fall back to certificate", err)
-			user, groups, err = identityFromCertificate(ctx)
-			if err != nil {
-				glog.Errorf("unable to get user and groups from certificate: %v", err)
-				return nil, err
-			}
-		}
-
-		return handler(newContextWithIdentity(ctx, user, groups), req)
-	}
-}
-
-// wrappedStream wraps a grpc.ServerStream associated with an incoming RPC, and
-// a custom context containing the user and groups derived from the client certificate
-// specified in the incoming RPC metadata
-type wrappedStream struct {
-	grpc.ServerStream
-	ctx context.Context
-}
-
-func (w *wrappedStream) Context() context.Context {
-	return w.ctx
-}
-
-func newWrappedStream(ctx context.Context, s grpc.ServerStream) grpc.ServerStream {
-	return &wrappedStream{s, ctx}
-}
-
-// newAuthStreamInterceptor creates a new stream interceptor that looks up the client certificate from the incoming RPC context,
-// retrieves the user and groups from it and creates a new context with the user and groups before invoking the provided handler.
-// otherwise, it falls back retrieving the user and groups from the access token.
-func newAuthStreamInterceptor(authorizer grpcauthorizer.GRPCAuthorizer) grpc.StreamServerInterceptor {
-	return func(
-		srv interface{},
-		ss grpc.ServerStream,
-		info *grpc.StreamServerInfo,
-		handler grpc.StreamHandler,
-	) error {
-		user, groups, err := identityFromToken(ss.Context(), authorizer)
-		if err != nil {
-			glog.Warningf("unable to get user and groups from token: %v, fall back to certificate", err)
-			user, groups, err = identityFromCertificate(ss.Context())
-			if err != nil {
-				glog.Errorf("unable to get user and groups from certificate: %v", err)
-				return err
-			}
-		}
-
-		return handler(srv, newWrappedStream(newContextWithIdentity(ss.Context(), user, groups), ss))
-	}
-}
 
 // GRPCServer includes a gRPC server and a resource service
 type GRPCServer struct {
@@ -238,10 +102,14 @@ func NewGRPCServer(resourceService services.ResourceService, eventBroadcaster *e
 			tlsConfig.ClientCAs = certPool
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 
-			grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsConfig)), grpc.UnaryInterceptor(newAuthUnaryInterceptor(grpcAuthorizer)), grpc.StreamInterceptor(newAuthStreamInterceptor(grpcAuthorizer)))
+			grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsConfig)),
+				grpc.UnaryInterceptor(newAuthUnaryInterceptor(config.GRPCAuthNType, grpcAuthorizer)),
+				grpc.StreamInterceptor(newAuthStreamInterceptor(config.GRPCAuthNType, grpcAuthorizer)))
 			glog.Infof("Serving gRPC service with mTLS at %s", config.ServerBindPort)
 		} else {
-			grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsConfig)), grpc.UnaryInterceptor(newAuthUnaryInterceptor(grpcAuthorizer)), grpc.StreamInterceptor(newAuthStreamInterceptor(grpcAuthorizer)))
+			grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsConfig)),
+				grpc.UnaryInterceptor(newAuthUnaryInterceptor(config.GRPCAuthNType, grpcAuthorizer)),
+				grpc.StreamInterceptor(newAuthStreamInterceptor(config.GRPCAuthNType, grpcAuthorizer)))
 			glog.Infof("Serving gRPC service with TLS at %s", config.ServerBindPort)
 		}
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/yaacov/tree-search-language v0.0.0-20190923184055-1c2dad2e354b
+	golang.org/x/oauth2 v0.16.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/resty.v1 v1.12.0
@@ -138,7 +139,6 @@ require (
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect

--- a/pkg/client/grpcauthorizer/interface.go
+++ b/pkg/client/grpcauthorizer/interface.go
@@ -1,0 +1,32 @@
+package grpcauthorizer
+
+import "context"
+
+// GRPCAuthorizer defines an interface for performing access reviews in a gRPC-based authorization.
+type GRPCAuthorizer interface {
+	// TokenReview validates the given token and returns the user and groups associated with it.
+	//
+	// Parameters:
+	// - ctx: The context for managing request lifecycle.
+	// - token: The token to validate.
+	//
+	// Returns:
+	// - user: The user associated with the token.
+	// - groups: The groups associated with the token.
+	// - err: Any error encountered during the review process.
+	TokenReview(ctx context.Context, token string) (user string, groups []string, err error)
+	// AccessReview checks if the specified user or groups has permission to perform a given action on a specified resource.
+	//
+	// Parameters:
+	// - ctx: The context for managing request lifecycle.
+	// - action: The action being requested, e.g., "pub" (publish) or "sub" (subscribe).
+	// - resourceType: The type of resource, e.g., "source" or "cluster".
+	// - resource: The specific resource name within the given resource type.
+	// - user: The user requesting the action (may be empty if groups are used).
+	// - groups: The groups requesting the action (may be empty if user is used).
+	//
+	// Returns:
+	// - allowed: True if access is granted, false otherwise.
+	// - err: Any error encountered during the review process.
+	AccessReview(ctx context.Context, action, resourceType, resource, user string, groups []string) (allowed bool, err error)
+}

--- a/pkg/client/grpcauthorizer/kube_authorizer.go
+++ b/pkg/client/grpcauthorizer/kube_authorizer.go
@@ -63,8 +63,6 @@ func (k *KubeGRPCAuthorizer) AccessReview(ctx context.Context, action, resourceT
 	switch resourceType {
 	case "source":
 		nonResourceUrl = fmt.Sprintf("/sources/%s", resource)
-	case "cluster":
-		nonResourceUrl = fmt.Sprintf("/clusters/%s", resource)
 	default:
 		return false, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}

--- a/pkg/client/grpcauthorizer/kube_authorizer.go
+++ b/pkg/client/grpcauthorizer/kube_authorizer.go
@@ -1,0 +1,88 @@
+package grpcauthorizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// KubeGRPCAuthorizer is a gRPC authorizer that uses the Kubernetes RBAC API to authorize requests.
+type KubeGRPCAuthorizer struct {
+	kubeClient kubernetes.Interface
+}
+
+func NewKubeGRPCAuthorizer(kubeClient kubernetes.Interface) GRPCAuthorizer {
+	return &KubeGRPCAuthorizer{
+		kubeClient: kubeClient,
+	}
+}
+
+var _ GRPCAuthorizer = &KubeGRPCAuthorizer{}
+
+// TokenReview validates the given token and returns the user and groups associated with it.
+func (k *KubeGRPCAuthorizer) TokenReview(ctx context.Context, token string) (user string, groups []string, err error) {
+	glog.V(4).Infof("TokenReview: token=%s", token)
+
+	tr, err := k.kubeClient.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{
+			Token: token,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return "", nil, err
+	}
+
+	if tr.Status.Authenticated {
+		return tr.Status.User.Username, tr.Status.User.Groups, nil
+	}
+
+	return "", nil, fmt.Errorf("token not authenticated")
+}
+
+// AccessReview checks if the given user or group is allowed to perform the given action on the given resource by making a SubjectAccessReview request.
+func (k *KubeGRPCAuthorizer) AccessReview(ctx context.Context, action, resourceType, resource, user string, groups []string) (allowed bool, err error) {
+	glog.V(4).Infof("AccessReview: action=%s, resourceType=%s, resource=%s, user=%s, groups=%s", action, resourceType, resource, user, groups)
+	if user != "" && len(groups) == 0 {
+		return false, fmt.Errorf("both user and groups cannot be specified")
+	}
+
+	if action != "pub" && action != "sub" {
+		return false, fmt.Errorf("unsupported action: %s", action)
+	}
+
+	if resource == "" {
+		return false, fmt.Errorf("resource cannot be empty")
+	}
+
+	nonResourceUrl := ""
+	switch resourceType {
+	case "source":
+		nonResourceUrl = fmt.Sprintf("/sources/%s", resource)
+	case "cluster":
+		nonResourceUrl = fmt.Sprintf("/clusters/%s", resource)
+	default:
+		return false, fmt.Errorf("unsupported resource type: %s", resourceType)
+	}
+
+	sar, err := k.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			NonResourceAttributes: &authorizationv1.NonResourceAttributes{
+				Path: nonResourceUrl,
+				Verb: action,
+			},
+			User:   user,
+			Groups: groups,
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		return false, err
+	}
+
+	return sar.Status.Allowed, nil
+}

--- a/pkg/client/grpcauthorizer/mock_authorizer.go
+++ b/pkg/client/grpcauthorizer/mock_authorizer.go
@@ -1,0 +1,23 @@
+package grpcauthorizer
+
+import "context"
+
+// MockGRPCAuthorizer returns allowed=true for every request
+type MockGRPCAuthorizer struct {
+}
+
+func NewMockGRPCAuthorizer() GRPCAuthorizer {
+	return &MockGRPCAuthorizer{}
+}
+
+var _ GRPCAuthorizer = &MockGRPCAuthorizer{}
+
+// TokenReview returns an empty user and groups
+func (m *MockGRPCAuthorizer) TokenReview(ctx context.Context, token string) (user string, groups []string, err error) {
+	return "", []string{}, nil
+}
+
+// SelfAccessReview returns allowed=true for every request
+func (m *MockGRPCAuthorizer) AccessReview(ctx context.Context, action, resourceType, resource, user string, groups []string) (allowed bool, err error) {
+	return true, nil
+}

--- a/pkg/config/grpc_server.go
+++ b/pkg/config/grpc_server.go
@@ -13,7 +13,7 @@ type GRPCServerConfig struct {
 	TLSCertFile           string        `json:"grpc_tls_cert_file"`
 	TLSKeyFile            string        `json:"grpc_tls_key_file"`
 	GRPCAuthNType         string        `json:"grpc_authn_type"`
-	GRPCAuthrizerConfig   string        `json:"grpc_authorizer_config"`
+	GRPCAuthorizerConfig  string        `json:"grpc_authorizer_config"`
 	ClientCAFile          string        `json:"grpc_client_ca_file"`
 	ServerBindPort        string        `json:"server_bind_port"`
 	BrokerBindPort        string        `json:"broker_bind_port"`
@@ -45,6 +45,6 @@ func (s *GRPCServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.TLSCertFile, "grpc-tls-cert-file", "", "The path to the tls.crt file")
 	fs.StringVar(&s.TLSKeyFile, "grpc-tls-key-file", "", "The path to the tls.key file")
 	fs.StringVar(&s.GRPCAuthNType, "grpc-authn-type", "mock", "Specify the gRPC authentication type (e.g., mock, mtls or token)")
-	fs.StringVar(&s.GRPCAuthrizerConfig, "grpc-authorizer-config", "", "Path to the gRPC authorizer configuration file")
+	fs.StringVar(&s.GRPCAuthorizerConfig, "grpc-authorizer-config", "", "Path to the gRPC authorizer configuration file")
 	fs.StringVar(&s.ClientCAFile, "grpc-client-ca-file", "", "The path to the client ca file, must specify if using mtls authentication type")
 }

--- a/pkg/config/grpc_server.go
+++ b/pkg/config/grpc_server.go
@@ -9,9 +9,12 @@ import (
 
 type GRPCServerConfig struct {
 	EnableGRPCServer      bool          `json:"enable_grpc_server"`
+	DisableTLS            bool          `json:"disable_grpc_tls"`
 	TLSCertFile           string        `json:"grpc_tls_cert_file"`
 	TLSKeyFile            string        `json:"grpc_tls_key_file"`
-	EnableTLS             bool          `json:"enable_grpc_tls"`
+	GRPCAuthNType         string        `json:"grpc_authn_type"`
+	GRPCAuthrizerConfig   string        `json:"grpc_authorizer_config"`
+	ClientCAFile          string        `json:"grpc_client_ca_file"`
 	ServerBindPort        string        `json:"server_bind_port"`
 	BrokerBindPort        string        `json:"broker_bind_port"`
 	MaxConcurrentStreams  uint32        `json:"max_concurrent_steams"`
@@ -38,7 +41,10 @@ func (s *GRPCServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.MaxConnectionAge, "grpc-max-connection-age", time.Duration(math.MaxInt64), "A duration for the maximum amount of time connection may exist before closing")
 	fs.IntVar(&s.WriteBufferSize, "grpc-write-buffer-size", 32*1024, "gPRC write buffer size")
 	fs.IntVar(&s.ReadBufferSize, "grpc-read-buffer-size", 32*1024, "gPRC read buffer size")
+	fs.BoolVar(&s.DisableTLS, "disable-grpc-tls", false, "Disable TLS for gRPC server, default is false")
 	fs.StringVar(&s.TLSCertFile, "grpc-tls-cert-file", "", "The path to the tls.crt file")
 	fs.StringVar(&s.TLSKeyFile, "grpc-tls-key-file", "", "The path to the tls.key file")
-	fs.BoolVar(&s.EnableTLS, "enable-grpc-tls", false, "Enable TLS for gRPC server")
+	fs.StringVar(&s.GRPCAuthNType, "grpc-authn-type", "mock", "Specify the gRPC authentication type (e.g., mock, mtls or token)")
+	fs.StringVar(&s.GRPCAuthrizerConfig, "grpc-authorizer-config", "", "Path to the gRPC authorizer configuration file")
+	fs.StringVar(&s.ClientCAFile, "grpc-client-ca-file", "", "The path to the client ca file, must specify if using mtls authentication type")
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -119,6 +119,11 @@ parameters:
   description: Message driver type, mqtt or grpc.
   value: mqtt
 
+- name: DISABLE_GRPC_TLS
+  displayName: Disable gRPC TLS
+  description: Disable TLS for gRPC server
+  value: "false"
+
 - name: METRICS_SERVER_BINDPORT
   displayName: Metrics Server Bindport
   description: Metrics server bind port
@@ -208,6 +213,31 @@ objects:
       name: maestro
       labels:
         app: maestro
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: maestro
+    rules:
+    - apiGroups: ["authorization.k8s.io"]
+      resources: ["subjectaccessreviews"]
+      verbs: ["create"]
+    - apiGroups: ["authentication.k8s.io"]
+      resources: ["tokenreviews"]
+      verbs: ["create"]
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: maestro
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: maestro
+    subjects:
+      - kind: ServiceAccount
+        name: maestro
+        namespace: maestro
 
   - kind: Deployment
     apiVersion: apps/v1
@@ -311,6 +341,7 @@ objects:
             - --https-cert-file=/secrets/tls/tls.crt
             - --https-key-file=/secrets/tls/tls.key
             - --enable-grpc-server=${ENABLE_GRPC_SERVER}
+            - --disable-grpc-tls=${DISABLE_GRPC_TLS}
             - --grpc-tls-cert-file=/secrets/tls/tls.crt
             - --grpc-tls-key-file=/secrets/tls/tls.key
             - --acl-file=/configs/authentication/acl.yml

--- a/test/e2e/pkg/grpc_test.go
+++ b/test/e2e/pkg/grpc_test.go
@@ -27,7 +27,6 @@ import (
 
 var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 	Context("GRPC Manifest Tests", func() {
-		source := "grpc-e2e"
 		deployName := fmt.Sprintf("nginx-%s", rand.String(5))
 		resourceID := uuid.NewString()
 		resourceStatus := &api.ResourceStatus{
@@ -36,7 +35,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 
 		It("subscribe to resource status with grpc client", func() {
 			go func() {
-				subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: source})
+				subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: sourceID})
 				if err != nil {
 					return
 				}
@@ -96,7 +95,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource spec using grpc client", func() {
-			evt := helper.NewEvent(source, "create_request", consumer.Name, resourceID, deployName, 1, 1)
+			evt := helper.NewEvent(sourceID, "create_request", consumer.Name, resourceID, deployName, 1, 1)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
@@ -153,7 +152,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource spec with update request using grpc client", func() {
-			evt := helper.NewEvent(source, "update_request", consumer.Name, resourceID, deployName, 1, 2)
+			evt := helper.NewEvent(sourceID, "update_request", consumer.Name, resourceID, deployName, 1, 2)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
@@ -210,7 +209,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource spec with delete request using grpc client", func() {
-			evt := helper.NewEvent(source, "delete_request", consumer.Name, resourceID, deployName, 2, 2)
+			evt := helper.NewEvent(sourceID, "delete_request", consumer.Name, resourceID, deployName, 2, 2)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
@@ -253,7 +252,6 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 	})
 
 	Context("GRPC Manifest Bundle Tests", func() {
-		source := "grpc-e2e"
 		deployName := fmt.Sprintf("nginx-%s", rand.String(5))
 		resourceID := uuid.NewString()
 		resourceBundleStatus := &api.ResourceBundleStatus{
@@ -262,7 +260,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 
 		It("subscribe to resource bundle status with grpc client", func() {
 			go func() {
-				subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: source})
+				subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: sourceID})
 				if err != nil {
 					return
 				}
@@ -304,7 +302,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource bundle spec using grpc client", func() {
-			evt := helper.NewBundleEvent(source, "create_request", consumer.Name, resourceID, deployName, 1, 1)
+			evt := helper.NewBundleEvent(sourceID, "create_request", consumer.Name, resourceID, deployName, 1, 1)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
@@ -376,7 +374,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource bundle spec with update request using grpc client", func() {
-			evt := helper.NewBundleEvent(source, "update_request", consumer.Name, resourceID, deployName, 1, 2)
+			evt := helper.NewBundleEvent(sourceID, "update_request", consumer.Name, resourceID, deployName, 1, 2)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
@@ -448,7 +446,7 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 		})
 
 		It("publish a resource bundle spec with delete request using grpc client", func() {
-			evt := helper.NewBundleEvent(source, "delete_request", consumer.Name, resourceID, deployName, 2, 2)
+			evt := helper.NewBundleEvent(sourceID, "delete_request", consumer.Name, resourceID, deployName, 2, 2)
 			pbEvt := &pbv1.CloudEvent{}
 			err := grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
 			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")

--- a/test/e2e/setup/e2e_setup.sh
+++ b/test/e2e/setup/e2e_setup.sh
@@ -88,7 +88,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: maestro-mqtt-server
-  namespace: maestro
 spec:
   ports:
   - name: mosquitto
@@ -103,7 +102,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: maestro-mqtt-agent
-  namespace: maestro
 spec:
   ports:
   - name: mosquitto
@@ -122,11 +120,11 @@ kubectl patch service maestro -n $namespace -p '{"spec":{"type":"NodePort", "por
 kubectl patch service maestro-grpc -n $namespace -p '{"spec":{"type":"NodePort", "ports":  [{"nodePort": 30090, "port": 8090, "targetPort": 8090}]}}' --type merge
 
 # 5. create a self-signed certificate for mqtt
-certDir=$(mktemp -d)
-step certificate create "maestro-mqtt-ca" ${certDir}/ca.crt ${certDir}/ca.key --profile root-ca --no-password --insecure
-step certificate create "maestro-mqtt-broker" ${certDir}/server.crt ${certDir}/server.key -san maestro-mqtt -san maestro-mqtt.maestro -san maestro-mqtt-server -san maestro-mqtt-server.maestro -san maestro-mqtt-agent -san maestro-mqtt-agent.maestro --profile leaf --ca ${certDir}/ca.crt --ca-key ${certDir}/ca.key --no-password --insecure
-step certificate create "maestro-server-client" ${certDir}/server-client.crt ${certDir}/server-client.key --profile leaf --ca ${certDir}/ca.crt --ca-key ${certDir}/ca.key --no-password --insecure
-step certificate create "maestro-agent-client" ${certDir}/agent-client.crt ${certDir}/agent-client.key --profile leaf --ca ${certDir}/ca.crt --ca-key ${certDir}/ca.key --no-password --insecure
+mqttCertDir=$(mktemp -d)
+step certificate create "maestro-mqtt-ca" ${mqttCertDir}/ca.crt ${mqttCertDir}/ca.key --profile root-ca --no-password --insecure
+step certificate create "maestro-mqtt-broker" ${mqttCertDir}/server.crt ${mqttCertDir}/server.key -san maestro-mqtt -san maestro-mqtt.maestro -san maestro-mqtt-server -san maestro-mqtt-server.maestro -san maestro-mqtt-agent -san maestro-mqtt-agent.maestro --profile leaf --ca ${mqttCertDir}/ca.crt --ca-key ${mqttCertDir}/ca.key --no-password --insecure
+step certificate create "maestro-server-client" ${mqttCertDir}/server-client.crt ${mqttCertDir}/server-client.key --profile leaf --ca ${mqttCertDir}/ca.crt --ca-key ${mqttCertDir}/ca.key --no-password --insecure
+step certificate create "maestro-agent-client" ${mqttCertDir}/agent-client.crt ${mqttCertDir}/agent-client.key --profile leaf --ca ${mqttCertDir}/ca.crt --ca-key ${mqttCertDir}/ca.key --no-password --insecure
 
 # apply the mosquitto configmap
 cat << EOF | kubectl -n $namespace apply -f -
@@ -147,13 +145,61 @@ data:
 EOF
 
 # create secret containing the mqtt certs and patch the maestro-mqtt deployment
-kubectl create secret generic maestro-mqtt-certs -n $namespace --from-file=ca.crt=${certDir}/ca.crt --from-file=server.crt=${certDir}/server.crt --from-file=server.key=${certDir}/server.key
+kubectl create secret generic maestro-mqtt-certs -n $namespace --from-file=ca.crt=${mqttCertDir}/ca.crt --from-file=server.crt=${mqttCertDir}/server.crt --from-file=server.key=${mqttCertDir}/server.key
 kubectl patch deploy/maestro-mqtt -n $namespace --type='json' -p='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mosquitto-certs","secret":{"secretName":"maestro-mqtt-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mosquitto-certs","mountPath":"/mosquitto/certs"}}]'
 kubectl wait deploy/maestro-mqtt -n $namespace --for condition=Available=True --timeout=200s
 
-maestroServerPatch='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mqtt-certs","secret":{"secretName":"maestro-server-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mqtt-certs","mountPath":"/secrets/mqtt-certs"}},{"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":1},{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":1}]'
+# 6. create a self-signed certificate for maestro grpc
+grpcCertDir=$(mktemp -d)
+step certificate create "maestro-grpc-ca" ${grpcCertDir}/ca.crt ${grpcCertDir}/ca.key --profile root-ca --no-password --insecure
+step certificate create "maestro-grpc-server" ${grpcCertDir}/server.crt ${grpcCertDir}/server.key -san maestro-grpc -san maestro-grpc.maestro -san localhost -san 127.0.0.1 --profile leaf --ca ${grpcCertDir}/ca.crt --ca-key ${grpcCertDir}/ca.key --no-password --insecure
+cat << EOF > ${grpcCertDir}/cert.tpl
+{
+    "subject":{"organization":"open-cluster-management","commonName":"grpc-client"},
+    "keyUsage":["digitalSignature"],
+    "extKeyUsage": ["serverAuth","clientAuth"]
+}
+EOF
+step certificate create "maestro-grpc-client" ${grpcCertDir}/client.crt ${grpcCertDir}/client.key --template ${grpcCertDir}/cert.tpl --ca ${grpcCertDir}/ca.crt --ca-key ${grpcCertDir}/ca.key --no-password --insecure
+kubectl create secret generic maestro-grpc-cert -n $namespace --from-file=ca.crt=${grpcCertDir}/ca.crt --from-file=server.crt=${grpcCertDir}/server.crt --from-file=server.key=${grpcCertDir}/server.key --from-file=client.crt=${grpcCertDir}/client.crt --from-file=client.key=${grpcCertDir}/client.key
+
+# create the grpc clusterrolebinding for publishing and subscribing
+cat << EOF | kubectl -n $namespace apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grpc-pub-sub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grpc-pub-sub
+subjects:
+- kind: User
+  name: grpc-client
+  apiGroup: rbac.authorization.k8s.io
+- kind: ServiceAccount
+  name: grpc-client
+  namespace: $namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grpc-client
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grpc-client-token
+  annotations:
+    kubernetes.io/service-account.name: grpc-client
+type: kubernetes.io/service-account-token
+---
+EOF
+
+# patch the maestro deployment to mount the grpc certs and mqtt certs
+maestroServerPatch='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mqtt-certs","secret":{"secretName":"maestro-server-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mqtt-certs","mountPath":"/secrets/mqtt-certs"}},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"maestro-grpc-cert","secret":{"secretName":"maestro-grpc-cert"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"maestro-grpc-cert","mountPath":"/secrets/maestro-grpc-cert"}},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-client-ca-file=/secrets/maestro-grpc-cert/ca.crt"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-authn-type=token"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-tls-cert-file=/secrets/maestro-grpc-cert/server.crt"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-tls-key-file=/secrets/maestro-grpc-cert/server.key"},{"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":1},{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":1}]'
 if [ -n "${ENABLE_BROADCAST_SUBSCRIPTION}" ] && [ "${ENABLE_BROADCAST_SUBSCRIPTION}" = "true" ]; then
-    maestroServerPatch='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--subscription-type=broadcast"},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mqtt-certs","secret":{"secretName":"maestro-server-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mqtt-certs","mountPath":"/secrets/mqtt-certs"}},{"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":1},{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":1}]'
+    maestroServerPatch='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--subscription-type=broadcast"},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mqtt-certs","secret":{"secretName":"maestro-server-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mqtt-certs","mountPath":"/secrets/mqtt-certs"}},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"maestro-grpc-cert","secret":{"secretName":"maestro-grpc-cert"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"maestro-grpc-cert","mountPath":"/secrets/maestro-grpc-cert"}},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-client-ca-file=/secrets/maestro-grpc-cert/ca.crt"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-authn-type=token"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-tls-cert-file=/secrets/maestro-grpc-cert/server.crt"},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--grpc-tls-key-file=/secrets/maestro-grpc-cert/server.key"},{"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":1},{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":1}]'
     cat << EOF | kubectl -n $namespace apply -f -
 apiVersion: v1
 kind: Secret
@@ -188,7 +234,7 @@ EOF
 fi
 
 # create secret containing the client certs to mqtt broker and patch the maestro deployment
-kubectl create secret generic maestro-server-certs -n $namespace --from-file=ca.crt=${certDir}/ca.crt --from-file=client.crt=${certDir}/server-client.crt --from-file=client.key=${certDir}/server-client.key
+kubectl create secret generic maestro-server-certs -n $namespace --from-file=ca.crt=${mqttCertDir}/ca.crt --from-file=client.crt=${mqttCertDir}/server-client.crt --from-file=client.key=${mqttCertDir}/server-client.key
 kubectl patch deploy/maestro -n $namespace --type='json' -p=${maestroServerPatch}
 kubectl wait deploy/maestro -n $namespace --for condition=Available=True --timeout=200s
 
@@ -217,7 +263,7 @@ metadata:
   name: maestro-agent-mqtt
 stringData:
   config.yaml: |
-    brokerHost: maestro-mqtt-agent.maestro:1883
+    brokerHost: maestro-mqtt-agent.${namespace}:1883
     caFile: /secrets/mqtt-certs/ca.crt
     clientCertFile: /secrets/mqtt-certs/client.crt
     clientKeyFile: /secrets/mqtt-certs/client.key
@@ -227,9 +273,9 @@ stringData:
 EOF
 
 # create secret containing the client certs to mqtt broker and patch the maestro-agent deployment
-kubectl create secret generic maestro-agent-certs -n ${agent_namespace} --from-file=ca.crt=${certDir}/ca.crt --from-file=client.crt=${certDir}/agent-client.crt --from-file=client.key=${certDir}/agent-client.key
+kubectl create secret generic maestro-agent-certs -n ${agent_namespace} --from-file=ca.crt=${mqttCertDir}/ca.crt --from-file=client.crt=${mqttCertDir}/agent-client.crt --from-file=client.key=${mqttCertDir}/agent-client.key
 kubectl patch deploy/maestro-agent -n ${agent_namespace} --type='json' -p='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--appliedmanifestwork-eviction-grace-period=30s"},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mqtt-certs","secret":{"secretName":"maestro-agent-certs"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mqtt-certs","mountPath":"/secrets/mqtt-certs"}}]'
 kubectl wait deploy/maestro-agent -n ${agent_namespace} --for condition=Available=True --timeout=200s
 
 # remove the certs
-rm -rf ${certDir}
+rm -rf ${mqttCertDir} ${grpcCertDir}

--- a/test/helper.go
+++ b/test/helper.go
@@ -160,6 +160,7 @@ func (helper *Helper) Teardown() {
 func (helper *Helper) startAPIServer() {
 	// TODO jwk mock server needs to be refactored out of the helper and into the testing environment
 	helper.Env().Config.HTTPServer.JwkCertURL = jwkURL
+	helper.Env().Config.GRPCServer.DisableTLS = true
 	helper.APIServer = server.NewAPIServer(helper.EventBroadcaster)
 	go func() {
 		glog.V(10).Info("Test API server started")


### PR DESCRIPTION
Add authentication and authorization for gRPC server, using kube authorizer:
- mtls based authorization
- token based authorization

how to configure authentication and authorization doc: https://github.com/morvencao/openshift-online-maestro/blob/br_grpc_auth/docs/grpc.md#authentication-and-authorization

ref:
- https://issues.redhat.com/browse/ACM-13115
- https://issues.redhat.com/browse/ACM-13116