### PR TITLE
Fix integration issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ help:
 
 # Encourage consistent tool versions
 OPENAPI_GENERATOR_VERSION:=5.4.0
-GO_VERSION:=go1.21.
+GO_VERSION:=go1.22.
 
 ### Constants:
 version:=$(shell date +%s)

--- a/test/factories.go
+++ b/test/factories.go
@@ -220,6 +220,7 @@ func (helper *Helper) CreateResource(consumerName string, replicas int) *api.Res
 func (helper *Helper) CreateResourceList(consumerName string, count int) (resources []*api.Resource) {
 	for i := 1; i <= count; i++ {
 		resources = append(resources, helper.CreateResource(consumerName, 1))
+		time.Sleep(10 * time.Millisecond)
 	}
 	return resources
 }

--- a/test/integration/consumers_test.go
+++ b/test/integration/consumers_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"gopkg.in/resty.v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/openshift-online/maestro/pkg/api/openapi"
 	"github.com/openshift-online/maestro/test"
@@ -29,7 +30,7 @@ func TestConsumerGet(t *testing.T) {
 	Expect(err).To(HaveOccurred(), "Expected 404")
 	Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
-	consumer := h.CreateConsumerWithLabels("cluster1", map[string]string{"foo": "bar"})
+	consumer := h.CreateConsumerWithLabels("cluster-"+rand.String(5), map[string]string{"foo": "bar"})
 
 	found, resp, err := client.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, consumer.ID).Execute()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
fix some issues in integration test:
1. use random consumer name to avoid the potential influence
2. remove workagent to fix the error
```
        Expected success, but got an error:
            <*errors.errorString | 0xc000e4b540>:
            should have 150 update status events but got 156
            {
                s: "should have 150 update status events but got 156",
            }
--- FAIL: TestControllerRacing (15.30s)
```
3. wait for 3 seconds to ensure the controller manager and status controller start to work to avoid the error
```
Expected success, but got an error:
            <*errors.errorString | 0xc0011f5210>:
            should have only 50 create events but got 49
            {
                s: "should have only 50 create events but got 49",
            }
```
