### PR TITLE
enhance log format using zapr logger.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ mqtt_password_file=${PWD}/secrets/mqtt.password
 mqtt_config_file=${PWD}/secrets/mqtt.config
 
 # Log verbosity level
-glog_v:=10
+klog_v:=10
 
 # Location of the JSON web key set used to verify tokens:
 jwks_url:=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
@@ -269,7 +269,7 @@ cmds:
 		--local="true" \
 		--ignore-unknown-parameters="true" \
 		--param="ENVIRONMENT=$(OCM_ENV)" \
-		--param="GLOG_V=$(glog_v)" \
+		--param="KLOG_V=$(klog_v)" \
 		--param="SERVER_REPLICAS=$(SERVER_REPLICAS)" \
 		--param="DATABASE_HOST=$(db_host)" \
 		--param="DATABASE_NAME=$(db_name)" \

--- a/cmd/maestro/agent/cmd.go
+++ b/cmd/maestro/agent/cmd.go
@@ -2,16 +2,13 @@ package agent
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/version"
-	"k8s.io/klog/v2"
 	ocmfeature "open-cluster-management.io/api/feature"
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"open-cluster-management.io/ocm/pkg/features"
@@ -38,17 +35,8 @@ func NewAgentCommand() *cobra.Command {
 	cmd.Short = "Start the Maestro Agent"
 	cmd.Long = "Start the Maestro Agent"
 
-	// check if the flag is already registered to avoid duplicate flag define error
-	if flag.CommandLine.Lookup("alsologtostderr") != nil {
-		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	}
-
-	// add klog flags
-	klog.InitFlags(nil)
-
-	flags := cmd.Flags()
+	flags := cmd.PersistentFlags()
 	flags.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	flags.AddGoFlagSet(flag.CommandLine)
 
 	// add common flags
 	// commonOptions.AddFlags(flags)
@@ -58,8 +46,11 @@ func NewAgentCommand() *cobra.Command {
 	// add alias flags
 	addFlags(flags)
 
-	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
-	utilruntime.Must(features.SpokeMutableFeatureGate.Set(fmt.Sprintf("%s=true", ocmfeature.RawFeedbackJsonString)))
+	// add pre-run to set feature gates
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
+		utilruntime.Must(features.SpokeMutableFeatureGate.Set(fmt.Sprintf("%s=true", ocmfeature.RawFeedbackJsonString)))
+	}
 
 	return cmd
 }

--- a/cmd/maestro/environments/framework.go
+++ b/cmd/maestro/environments/framework.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/client/cloudevents"
 	"github.com/openshift-online/maestro/pkg/client/grpcauthorizer"
 	"github.com/openshift-online/maestro/pkg/client/ocm"
@@ -16,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
 )
@@ -76,36 +76,36 @@ func (e *Env) AddFlags(flags *pflag.FlagSet) error {
 // This should be called after the e.Config has been set appropriately though AddFlags and pasing, done elsewhere
 // The environment does NOT handle flag parsing
 func (e *Env) Initialize() error {
-	glog.Infof("Initializing %s environment", e.Name)
+	klog.Infof("Initializing %s environment", e.Name)
 
 	envImpl, found := environments[e.Name]
 	if !found {
-		glog.Fatalf("Unknown runtime environment: %s", e.Name)
+		klog.Fatalf("Unknown runtime environment: %s", e.Name)
 	}
 
 	if err := envImpl.VisitConfig(&e.ApplicationConfig); err != nil {
-		glog.Fatalf("Failed to visit ApplicationConfig: %s", err)
+		klog.Fatalf("Failed to visit ApplicationConfig: %s", err)
 	}
 
 	messages := environment.Config.ReadFiles()
 	if len(messages) != 0 {
 		err := fmt.Errorf("unable to read configuration files:\n%s", strings.Join(messages, "\n"))
 		sentry.CaptureException(err)
-		glog.Fatalf("Unable to read configuration files:\n%s", strings.Join(messages, "\n"))
+		klog.Fatalf("Unable to read configuration files:\n%s", strings.Join(messages, "\n"))
 	}
 
 	// each env will set db explicitly because the DB impl has a `once` init section
 	if err := envImpl.VisitDatabase(&e.Database); err != nil {
-		glog.Fatalf("Failed to visit Database: %s", err)
+		klog.Fatalf("Failed to visit Database: %s", err)
 	}
 
 	if err := envImpl.VisitMessageBroker(&e.MessageBroker); err != nil {
-		glog.Fatalf("Failed to visit MessageBroker: %s", err)
+		klog.Fatalf("Failed to visit MessageBroker: %s", err)
 	}
 
 	e.LoadServices()
 	if err := envImpl.VisitServices(&e.Services); err != nil {
-		glog.Fatalf("Failed to visit Services: %s", err)
+		klog.Fatalf("Failed to visit Services: %s", err)
 	}
 
 	// Load clients after services so that clients can use services
@@ -114,7 +114,7 @@ func (e *Env) Initialize() error {
 		return err
 	}
 	if err := envImpl.VisitClients(&e.Clients); err != nil {
-		glog.Fatalf("Failed to visit Clients: %s", err)
+		klog.Fatalf("Failed to visit Clients: %s", err)
 	}
 
 	err = e.InitializeSentry()
@@ -129,7 +129,7 @@ func (e *Env) Initialize() error {
 
 	if _, ok := envImpl.(HandlerVisitor); ok {
 		if err := (envImpl.(HandlerVisitor)).VisitHandlers(&e.Handlers); err != nil {
-			glog.Fatalf("Failed to visit Handlers: %s", err)
+			klog.Fatalf("Failed to visit Handlers: %s", err)
 		}
 	}
 
@@ -162,19 +162,19 @@ func (e *Env) LoadClients() error {
 
 	// Create OCM Authz client
 	if e.Config.OCM.EnableMock {
-		glog.Infof("Using Mock OCM Authz Client")
+		klog.Infof("Using Mock OCM Authz Client")
 		e.Clients.OCM, err = ocm.NewClientMock(ocmConfig)
 	} else {
 		e.Clients.OCM, err = ocm.NewClient(ocmConfig)
 	}
 	if err != nil {
-		glog.Errorf("Unable to create OCM Authz client: %s", err.Error())
+		klog.Errorf("Unable to create OCM Authz client: %s", err.Error())
 		return err
 	}
 
 	// Create CloudEvents Source client
 	if e.Config.MessageBroker.EnableMock {
-		glog.Infof("Using Mock CloudEvents Source Client")
+		klog.Infof("Using Mock CloudEvents Source Client")
 		e.Clients.CloudEventsSource = cloudevents.NewSourceClientMock(e.Services.Resources())
 	} else {
 		// For gRPC message broker type, Maestro server does not require the source client to publish resources or subscribe to resource status.
@@ -182,19 +182,19 @@ func (e *Env) LoadClients() error {
 			_, config, err := generic.NewConfigLoader(e.Config.MessageBroker.MessageBrokerType, e.Config.MessageBroker.MessageBrokerConfig).
 				LoadConfig()
 			if err != nil {
-				glog.Errorf("Unable to load configuration: %s", err.Error())
+				klog.Errorf("Unable to load configuration: %s", err.Error())
 				return err
 			}
 
 			cloudEventsSourceOptions, err := generic.BuildCloudEventsSourceOptions(config,
 				e.Config.MessageBroker.ClientID, e.Config.MessageBroker.SourceID)
 			if err != nil {
-				glog.Errorf("Unable to build cloudevent source options: %s", err.Error())
+				klog.Errorf("Unable to build cloudevent source options: %s", err.Error())
 				return err
 			}
 			e.Clients.CloudEventsSource, err = cloudevents.NewSourceClient(cloudEventsSourceOptions, e.Services.Resources())
 			if err != nil {
-				glog.Errorf("Unable to create CloudEvents Source client: %s", err.Error())
+				klog.Errorf("Unable to create CloudEvents Source client: %s", err.Error())
 				return err
 			}
 		}
@@ -203,22 +203,22 @@ func (e *Env) LoadClients() error {
 	// Create GRPC authorizer based on configuration
 	if e.Config.GRPCServer.EnableGRPCServer {
 		if e.Config.GRPCServer.GRPCAuthNType == "mock" {
-			glog.Infof("Using Mock GRPC Authorizer")
+			klog.Infof("Using Mock GRPC Authorizer")
 			e.Clients.GRPCAuthorizer = grpcauthorizer.NewMockGRPCAuthorizer()
 		} else {
 			kubeConfig, err := clientcmd.BuildConfigFromFlags("", e.Config.GRPCServer.GRPCAuthorizerConfig)
 			if err != nil {
-				glog.Warningf("Unable to create kube client config: %s", err.Error())
+				klog.Warningf("Unable to create kube client config: %s", err.Error())
 				// fallback to in-cluster config
 				kubeConfig, err = rest.InClusterConfig()
 				if err != nil {
-					glog.Errorf("Unable to create kube client config: %s", err.Error())
+					klog.Errorf("Unable to create kube client config: %s", err.Error())
 					return err
 				}
 			}
 			kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 			if err != nil {
-				glog.Errorf("Unable to create kube client: %s", err.Error())
+				klog.Errorf("Unable to create kube client: %s", err.Error())
 				return err
 			}
 			e.Clients.GRPCAuthorizer = grpcauthorizer.NewKubeGRPCAuthorizer(kubeClient)
@@ -235,12 +235,12 @@ func (e *Env) InitializeSentry() error {
 		key := e.Config.Sentry.Key
 		url := e.Config.Sentry.URL
 		project := e.Config.Sentry.Project
-		glog.Infof("Sentry error reporting enabled to %s on project %s", url, project)
+		klog.Infof("Sentry error reporting enabled to %s on project %s", url, project)
 		options.Dsn = fmt.Sprintf("https://%s@%s/%s", key, url, project)
 	} else {
 		// Setting the DSN to an empty string effectively disables sentry
 		// See https://godoc.org/github.com/getsentry/sentry-go#ClientOptions Dsn
-		glog.Infof("Disabling Sentry error reporting")
+		klog.Infof("Disabling Sentry error reporting")
 		options.Dsn = ""
 	}
 
@@ -264,7 +264,7 @@ func (e *Env) InitializeSentry() error {
 
 	err = sentry.Init(options)
 	if err != nil {
-		glog.Errorf("Unable to initialize sentry integration: %s", err.Error())
+		klog.Errorf("Unable to initialize sentry integration: %s", err.Error())
 		return err
 	}
 	return nil
@@ -273,7 +273,7 @@ func (e *Env) InitializeSentry() error {
 func (e *Env) Teardown() {
 	if e.Name != TestingEnv {
 		if err := e.Database.SessionFactory.Close(); err != nil {
-			glog.Fatalf("Unable to close db connection: %s", err.Error())
+			klog.Fatalf("Unable to close db connection: %s", err.Error())
 		}
 		e.Clients.OCM.Close()
 	}
@@ -282,7 +282,7 @@ func (e *Env) Teardown() {
 func setConfigDefaults(flags *pflag.FlagSet, defaults map[string]string) error {
 	for name, value := range defaults {
 		if err := flags.Set(name, value); err != nil {
-			glog.Errorf("Error setting flag %s: %v", name, err)
+			klog.Errorf("Error setting flag %s: %v", name, err)
 			return err
 		}
 	}

--- a/cmd/maestro/migrate/cmd.go
+++ b/cmd/maestro/migrate/cmd.go
@@ -2,11 +2,10 @@ package migrate
 
 import (
 	"context"
-	"flag"
 
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/db/db_session"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/pkg/config"
 	"github.com/openshift-online/maestro/pkg/db"
@@ -24,18 +23,17 @@ func NewMigrationCommand() *cobra.Command {
 	}
 
 	dbConfig.AddFlags(cmd.PersistentFlags())
-	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 
 func runMigration(_ *cobra.Command, _ []string) {
 	err := dbConfig.ReadFiles()
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	connection := db_session.NewProdFactory(dbConfig)
 	if err := db.Migrate(connection.New(context.Background())); err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 }

--- a/cmd/maestro/servecmd/cmd.go
+++ b/cmd/maestro/servecmd/cmd.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/cmd/maestro/environments"
 	"github.com/openshift-online/maestro/cmd/maestro/server"
@@ -23,7 +23,7 @@ func NewServerCommand() *cobra.Command {
 	}
 	err := environments.Environment().AddFlags(cmd.PersistentFlags())
 	if err != nil {
-		glog.Fatalf("Unable to add environment flags to serve command: %s", err.Error())
+		klog.Fatalf("Unable to add environment flags to serve command: %s", err.Error())
 	}
 
 	return cmd
@@ -32,7 +32,7 @@ func NewServerCommand() *cobra.Command {
 func runServer(cmd *cobra.Command, args []string) {
 	err := environments.Environment().Initialize()
 	if err != nil {
-		glog.Fatalf("Unable to initialize environment: %s", err.Error())
+		klog.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
 
 	// Create event broadcaster to broadcast resource status update events to subscribers
@@ -43,10 +43,10 @@ func runServer(cmd *cobra.Command, args []string) {
 	// For MQTT, create a Pulse server to handle resource spec and status events.
 	var eventServer server.EventServer
 	if environments.Environment().Config.MessageBroker.MessageBrokerType == "grpc" {
-		glog.Info("Setting up grpc broker")
+		klog.Info("Setting up grpc broker")
 		eventServer = server.NewGRPCBroker(eventBroadcaster)
 	} else {
-		glog.Info("Setting up pulse server")
+		klog.Info("Setting up pulse server")
 		eventServer = server.NewPulseServer(eventBroadcaster)
 	}
 	// Create the servers
@@ -64,15 +64,15 @@ func runServer(cmd *cobra.Command, args []string) {
 		<-stopCh
 		// Received SIGTERM or SIGINT signal, shutting down servers gracefully.
 		if err := apiserver.Stop(); err != nil {
-			glog.Errorf("Failed to stop api server, %v", err)
+			klog.Errorf("Failed to stop api server, %v", err)
 		}
 
 		if err := metricsServer.Stop(); err != nil {
-			glog.Errorf("Failed to stop metrics server, %v", err)
+			klog.Errorf("Failed to stop metrics server, %v", err)
 		}
 
 		if err := healthcheckServer.Stop(); err != nil {
-			glog.Errorf("Failed to stop healthcheck server, %v", err)
+			klog.Errorf("Failed to stop healthcheck server, %v", err)
 		}
 	}()
 

--- a/cmd/maestro/server/api_server.go
+++ b/cmd/maestro/server/api_server.go
@@ -15,6 +15,7 @@ import (
 	gorillahandlers "github.com/gorilla/handlers"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift-online/ocm-sdk-go/authentication"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/cmd/maestro/environments"
 	"github.com/openshift-online/maestro/data/generated/openapi"
@@ -144,16 +145,16 @@ func (s apiServer) Serve(listener net.Listener) {
 		}
 
 		// Serve with TLS
-		glog.Infof("Serving with TLS at %s", env().Config.HTTPServer.BindPort)
+		klog.Infof("Serving with TLS at %s", env().Config.HTTPServer.BindPort)
 		err = s.httpServer.ServeTLS(listener, env().Config.HTTPServer.HTTPSCertFile, env().Config.HTTPServer.HTTPSKeyFile)
 	} else {
-		glog.Infof("Serving without TLS at %s", env().Config.HTTPServer.BindPort)
+		klog.Infof("Serving without TLS at %s", env().Config.HTTPServer.BindPort)
 		err = s.httpServer.Serve(listener)
 	}
 
 	// Web server terminated.
 	check(err, "Web server terminated with errors")
-	glog.Info("Web server terminated")
+	klog.Info("Web server terminated")
 }
 
 // Listen only start the listener, not the server.
@@ -173,7 +174,7 @@ func (s apiServer) Start() {
 
 	listener, err := s.Listen()
 	if err != nil {
-		glog.Fatalf("Unable to start API server: %s", err)
+		klog.Fatalf("Unable to start API server: %s", err)
 	}
 	s.Serve(listener)
 

--- a/cmd/maestro/server/auth_interceptor.go
+++ b/cmd/maestro/server/auth_interceptor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/client/grpcauthorizer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -13,6 +12,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 )
 
 // Context key type defined to avoid collisions in other pkgs using context
@@ -101,13 +101,13 @@ func newAuthUnaryInterceptor(authNType string, authorizer grpcauthorizer.GRPCAut
 		case "token":
 			user, groups, err = identityFromToken(ctx, authorizer)
 			if err != nil {
-				glog.Errorf("unable to get user and groups from token: %v", err)
+				klog.Errorf("unable to get user and groups from token: %v", err)
 				return nil, err
 			}
 		case "mtls":
 			user, groups, err = identityFromCertificate(ctx)
 			if err != nil {
-				glog.Errorf("unable to get user and groups from certificate: %v", err)
+				klog.Errorf("unable to get user and groups from certificate: %v", err)
 				return nil, err
 			}
 		default:
@@ -156,13 +156,13 @@ func newAuthStreamInterceptor(authNType string, authorizer grpcauthorizer.GRPCAu
 		case "token":
 			user, groups, err = identityFromToken(ss.Context(), authorizer)
 			if err != nil {
-				glog.Errorf("unable to get user and groups from token: %v", err)
+				klog.Errorf("unable to get user and groups from token: %v", err)
 				return err
 			}
 		case "mtls":
 			user, groups, err = identityFromCertificate(ss.Context())
 			if err != nil {
-				glog.Errorf("unable to get user and groups from certificate: %v", err)
+				klog.Errorf("unable to get user and groups from certificate: %v", err)
 				return err
 			}
 		default:

--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	health "github.com/docker/go-healthcheck"
-	"github.com/golang/glog"
 	"github.com/gorilla/mux"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -50,14 +50,14 @@ func (s healthCheckServer) Start() {
 		}
 
 		// Serve with TLS
-		glog.Infof("Serving HealthCheck with TLS at %s", env().Config.HealthCheck.BindPort)
+		klog.Infof("Serving HealthCheck with TLS at %s", env().Config.HealthCheck.BindPort)
 		err = s.httpServer.ListenAndServeTLS(env().Config.HTTPServer.HTTPSCertFile, env().Config.HTTPServer.HTTPSKeyFile)
 	} else {
-		glog.Infof("Serving HealthCheck without TLS at %s", env().Config.HealthCheck.BindPort)
+		klog.Infof("Serving HealthCheck without TLS at %s", env().Config.HealthCheck.BindPort)
 		err = s.httpServer.ListenAndServe()
 	}
 	check(err, "HealthCheck server terminated with errors")
-	glog.Infof("HealthCheck server terminated")
+	klog.Infof("HealthCheck server terminated")
 }
 
 func (s healthCheckServer) Stop() error {

--- a/cmd/maestro/server/logging/formatter_json.go
+++ b/cmd/maestro/server/logging/formatter_json.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/glog"
+	"k8s.io/klog/v2"
 )
 
 func NewJSONLogFormatter() *jsonLogFormatter {
@@ -22,7 +22,7 @@ func (f *jsonLogFormatter) FormatRequestLog(r *http.Request) (string, error) {
 		RequestURI: r.RequestURI,
 		RemoteAddr: r.RemoteAddr,
 	}
-	if glog.V(10) {
+	if klog.V(10).Enabled() {
 		jsonlog.Header = r.Header
 		jsonlog.Body = r.Body
 	}
@@ -36,7 +36,7 @@ func (f *jsonLogFormatter) FormatRequestLog(r *http.Request) (string, error) {
 
 func (f *jsonLogFormatter) FormatResponseLog(info *ResponseInfo) (string, error) {
 	jsonlog := jsonResponseLog{Header: nil, Status: info.Status, Elapsed: info.Elapsed}
-	if glog.V(10) {
+	if klog.V(10).Enabled() {
 		jsonlog.Body = string(info.Body[:])
 	}
 	log, err := json.Marshal(jsonlog)

--- a/cmd/maestro/server/pulse_server.go
+++ b/cmd/maestro/server/pulse_server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/api"
 	"github.com/openshift-online/maestro/pkg/client/cloudevents"
 	"github.com/openshift-online/maestro/pkg/config"
@@ -17,6 +16,7 @@ import (
 	"github.com/openshift-online/maestro/pkg/services"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/common"
 	workpayload "open-cluster-management.io/sdk-go/pkg/cloudevents/work/payload"
@@ -73,7 +73,7 @@ func NewPulseServer(eventBroadcaster *event.EventBroadcaster) EventServer {
 		statusDispatcher = dispatcher.NewHashDispatcher(env().Config.MessageBroker.ClientID, dao.NewInstanceDao(&env().Database.SessionFactory),
 			dao.NewConsumerDao(&env().Database.SessionFactory), env().Clients.CloudEventsSource, env().Config.PulseServer.ConsistentHashConfig)
 	default:
-		glog.Fatalf("Unsupported subscription type: %s", env().Config.PulseServer.SubscriptionType)
+		klog.Fatalf("Unsupported subscription type: %s", env().Config.PulseServer.SubscriptionType)
 	}
 	sessionFactory := env().Database.SessionFactory
 	return &PulseServer{

--- a/cmd/maestro/server/server.go
+++ b/cmd/maestro/server/server.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/golang/glog"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/cmd/maestro/environments"
 )
@@ -29,7 +29,7 @@ func removeTrailingSlash(next http.Handler) http.Handler {
 // Exit on error
 func check(err error, msg string) {
 	if err != nil && err != http.ErrServerClosed {
-		glog.Errorf("%s: %s", msg, err)
+		klog.Errorf("%s: %s", msg, err)
 		sentry.CaptureException(err)
 		sentry.Flush(environments.Environment().Config.Sentry.Timeout)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/getsentry/sentry-go v0.20.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
+	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/glog v1.2.1
 	github.com/google/uuid v1.6.0
@@ -36,6 +37,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/yaacov/tree-search-language v0.0.0-20190923184055-1c2dad2e354b
+	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.20.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
@@ -136,7 +138,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.28.0 // indirect

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/errors"
+	"k8s.io/klog/v2"
 )
 
 // SendNotFound sends a 404 response with some details about the non existing resource.
@@ -40,7 +40,7 @@ func SendNotFound(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(data)
 	if err != nil {
 		err = fmt.Errorf("cannot send response body for request '%s'", r.URL.Path)
-		glog.Error(err)
+		klog.Error(err)
 		sentry.CaptureException(err)
 		return
 	}
@@ -62,7 +62,7 @@ func SendUnauthorized(w http.ResponseWriter, r *http.Request, message string) {
 	_, err = w.Write(data)
 	if err != nil {
 		err = fmt.Errorf("cannot send response body for request '%s'", r.URL.Path)
-		glog.Error(err)
+		klog.Error(err)
 		sentry.CaptureException(err)
 		return
 	}
@@ -78,7 +78,7 @@ func SendPanic(w http.ResponseWriter, r *http.Request) {
 			r.URL.Path,
 			err.Error(),
 		)
-		glog.Error(err)
+		klog.Error(err)
 		sentry.CaptureException(err)
 	}
 }
@@ -109,7 +109,7 @@ func init() {
 			"cannot create the panic error body: %s",
 			err.Error(),
 		)
-		glog.Error(err)
+		klog.Error(err)
 		sentry.CaptureException(err)
 		os.Exit(1)
 	}

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/golang/glog"
+	"k8s.io/klog/v2"
 )
 
 // SendAPI sends API documentation response.
@@ -55,7 +55,7 @@ func SendAPI(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(data)
 	if err != nil {
 		err = fmt.Errorf("cannot send response body for request '%s'", r.URL.Path)
-		glog.Error(err)
+		klog.Error(err)
 		sentry.CaptureException(err)
 		return
 	}
@@ -90,7 +90,7 @@ func SendAPIV1(w http.ResponseWriter, r *http.Request) {
 	// Send the response:
 	_, err = w.Write(data)
 	if err != nil {
-		glog.Errorf("Can't send response body for request '%s'", r.URL.Path)
+		klog.Errorf("Can't send response body for request '%s'", r.URL.Path)
 		return
 	}
 }

--- a/pkg/auth/authz_middleware_mock.go
+++ b/pkg/auth/authz_middleware_mock.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"net/http"
 
-	"github.com/golang/glog"
+	"k8s.io/klog/v2"
 )
 
 type authzMiddlewareMock struct{}
@@ -16,7 +16,7 @@ func NewAuthzMiddlewareMock() AuthorizationMiddleware {
 
 func (a authzMiddlewareMock) AuthorizeApi(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		glog.V(10).Infof("Mock authz allows <any>/<any> for %q/%q", r.Method, r.URL)
+		klog.V(10).Infof("Mock authz allows <any>/<any> for %q/%q", r.Method, r.URL)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/client/grpcauthorizer/kube_authorizer.go
+++ b/pkg/client/grpcauthorizer/kube_authorizer.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // KubeGRPCAuthorizer is a gRPC authorizer that uses the Kubernetes RBAC API to authorize requests.
@@ -26,7 +26,7 @@ var _ GRPCAuthorizer = &KubeGRPCAuthorizer{}
 
 // TokenReview validates the given token and returns the user and groups associated with it.
 func (k *KubeGRPCAuthorizer) TokenReview(ctx context.Context, token string) (user string, groups []string, err error) {
-	glog.V(4).Infof("TokenReview: token=%s", token)
+	klog.V(4).Infof("TokenReview: token=%s", token)
 
 	tr, err := k.kubeClient.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{
@@ -46,7 +46,7 @@ func (k *KubeGRPCAuthorizer) TokenReview(ctx context.Context, token string) (use
 
 // AccessReview checks if the given user or group is allowed to perform the given action on the given resource by making a SubjectAccessReview request.
 func (k *KubeGRPCAuthorizer) AccessReview(ctx context.Context, action, resourceType, resource, user string, groups []string) (allowed bool, err error) {
-	glog.V(4).Infof("AccessReview: action=%s, resourceType=%s, resource=%s, user=%s, groups=%s", action, resourceType, resource, user, groups)
+	klog.V(4).Infof("AccessReview: action=%s, resourceType=%s, resource=%s, user=%s, groups=%s", action, resourceType, resource, user, groups)
 	if user != "" && len(groups) == 0 {
 		return false, fmt.Errorf("both user and groups cannot be specified")
 	}

--- a/pkg/db/db_session/test.go
+++ b/pkg/db/db_session/test.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
-
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/pkg/config"
 	"github.com/openshift-online/maestro/pkg/db"
@@ -50,12 +49,12 @@ func (f *Test) Init(config *config.DatabaseConfig) {
 	// Only the first time
 	once.Do(func() {
 		if err := initDatabase(config, db.Migrate); err != nil {
-			glog.Errorf("error initializing test database: %s", err)
+			klog.Errorf("error initializing test database: %s", err)
 			return
 		}
 
 		if err := resetDB(config); err != nil {
-			glog.Errorf("error resetting test database: %s", err)
+			klog.Errorf("error resetting test database: %s", err)
 			return
 		}
 	})

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/go-gormigrate/gormigrate/v2"
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/db/migrations"
+	"k8s.io/klog/v2"
 
 	"gorm.io/gorm"
 )
@@ -30,7 +30,7 @@ func MigrateTo(sessionFactory SessionFactory, migrationID string) {
 	m := newGormigrate(g2)
 
 	if err := m.MigrateTo(migrationID); err != nil {
-		glog.Fatalf("Could not migrate: %v", err)
+		klog.Fatalf("Could not migrate: %v", err)
 	}
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/golang/glog"
-
 	"github.com/openshift-online/maestro/pkg/api/openapi"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -106,7 +105,7 @@ func New(code ServiceErrorCode, reason string, values ...interface{}) *ServiceEr
 	var err *ServiceError
 	exists, err := Find(code)
 	if !exists {
-		glog.Errorf("Undefined error code used: %d", code)
+		klog.Errorf("Undefined error code used: %d", code)
 		err = &ServiceError{ErrorGeneral, "Unspecified error", 500}
 	}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/openshift-online/maestro/pkg/api"
+	"k8s.io/klog/v2"
 )
 
 // resourceHandler is a function that can handle resource status change events.
@@ -51,7 +51,7 @@ func (h *EventBroadcaster) Register(source string, handler resourceHandler) (str
 		errChan: errChan,
 	}
 
-	glog.V(4).Infof("register a broadcaster client %s (source=%s)", id, source)
+	klog.V(4).Infof("register a broadcaster client %s (source=%s)", id, source)
 
 	return id, errChan
 }
@@ -72,7 +72,7 @@ func (h *EventBroadcaster) Broadcast(res *api.Resource) {
 
 // Start starts the event broadcaster and waits for events to broadcast.
 func (h *EventBroadcaster) Start(ctx context.Context) {
-	glog.Infof("Starting event broadcaster")
+	klog.Infof("Starting event broadcaster")
 
 	for {
 		select {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/golang/glog"
 	"github.com/openshift-online/maestro/pkg/util"
+	"k8s.io/klog/v2"
 )
 
 type OCMLogger interface {
@@ -100,7 +100,7 @@ func (l *logger) V(level int32) OCMLogger {
 // Infof doesn't trigger Sentry error
 func (l *logger) Infof(format string, args ...interface{}) {
 	prefixed := l.prepareLogPrefixf(format, args...)
-	glog.V(glog.Level(l.level)).Infof("%s", prefixed)
+	klog.V(klog.Level(l.level)).Infof("%s", prefixed)
 }
 
 func (l *logger) Extra(key string, value interface{}) OCMLogger {
@@ -109,24 +109,24 @@ func (l *logger) Extra(key string, value interface{}) OCMLogger {
 }
 
 func (l *logger) Info(message string) {
-	l.log(message, sentry.LevelInfo, glog.V(glog.Level(l.level)).Infoln)
+	l.log(message, sentry.LevelInfo, klog.V(klog.Level(l.level)).Infoln)
 }
 
 func (l *logger) Warning(message string) {
-	l.log(message, sentry.LevelWarning, glog.Warningln)
+	l.log(message, sentry.LevelWarning, klog.Warningln)
 }
 
 func (l *logger) Error(message string) {
-	l.log(message, sentry.LevelError, glog.Errorln)
+	l.log(message, sentry.LevelError, klog.Errorln)
 }
 
 func (l *logger) Fatal(message string) {
-	l.log(message, sentry.LevelFatal, glog.Fatalln)
+	l.log(message, sentry.LevelFatal, klog.Fatalln)
 }
 
-func (l *logger) log(message string, level sentry.Level, glogFunc func(args ...interface{})) {
+func (l *logger) log(message string, level sentry.Level, logFunc func(args ...interface{})) {
 	prefixed := l.prepareLogPrefix(message, l.extra)
-	glogFunc(prefixed)
+	logFunc(prefixed)
 	if level != sentry.LevelInfo && level != sentry.LevelWarning {
 		l.captureSentryEvent(level, message)
 	}

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -35,8 +35,8 @@ parameters:
   displayName: Image tag
   value: latest
 
-- name: GLOG_V
-  displayName: GLOG V Level
+- name: KLOG_V
+  displayName: KLOG V Level
   description: Log verbosity level
   value: "10"
 
@@ -216,7 +216,7 @@ objects:
             - --db-name-file=/secrets/db/db.name
             - --db-sslmode=${DB_SSLMODE}
             - --alsologtostderr
-            - -v=${GLOG_V}
+            - -v=${KLOG_V}
           containers:
           - name: service
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
@@ -269,7 +269,7 @@ objects:
             - --http-write-timeout=${HTTP_WRITE_TIMEOUT}
             - --label-metrics-inclusion-duration=${LABEL_METRICS_INCLUSION_DURATION}
             - --alsologtostderr
-            - -v=${GLOG_V}
+            - -v=${KLOG_V}
             resources:
               requests:
                 cpu: ${CPU_REQUEST}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -44,8 +44,8 @@ parameters:
   displayName: Image tag
   value: "7"
 
-- name: GLOG_V
-  displayName: GLOG V Level
+- name: KLOG_V
+  displayName: KLOG V Level
   description: Log verbosity level
   value: "10"
 
@@ -297,7 +297,7 @@ objects:
             - --db-rootcert=/secrets/rds/db.ca_cert
             - --db-sslmode=${DB_SSLMODE}
             - --alsologtostderr
-            - -v=${GLOG_V}
+            - -v=${KLOG_V}
           containers:
           - name: service
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
@@ -369,7 +369,7 @@ objects:
             - --http-write-timeout=${HTTP_WRITE_TIMEOUT}
             - --label-metrics-inclusion-duration=${LABEL_METRICS_INCLUSION_DURATION}
             - --alsologtostderr
-            - -v=${GLOG_V}
+            - -v=${KLOG_V}
             resources:
               requests:
                 cpu: ${CPU_REQUEST}

--- a/test/helper.go
+++ b/test/helper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-online/maestro/pkg/controllers"
 	"github.com/openshift-online/maestro/pkg/event"
 	"github.com/openshift-online/maestro/pkg/logger"
+	"k8s.io/klog/v2"
 
 	workinformers "open-cluster-management.io/api/client/work/informers/externalversions"
 	workv1informers "open-cluster-management.io/api/client/work/informers/externalversions/work/v1"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/bxcodec/faker/v3"
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/segmentio/ksuid"
 	"github.com/spf13/pflag"
@@ -100,17 +100,17 @@ func NewHelper(t *testing.T) *Helper {
 		env.Name = environments.TestingEnv
 		err = env.AddFlags(pflag.CommandLine)
 		if err != nil {
-			glog.Fatalf("Unable to add environment flags: %s", err.Error())
+			klog.Fatalf("Unable to add environment flags: %s", err.Error())
 		}
 		if logLevel := os.Getenv("LOGLEVEL"); logLevel != "" {
-			glog.Infof("Using custom loglevel: %s", logLevel)
+			klog.Infof("Using custom loglevel: %s", logLevel)
 			pflag.CommandLine.Set("-v", logLevel)
 		}
 		pflag.Parse()
 
 		err = env.Initialize()
 		if err != nil {
-			glog.Fatalf("Unable to initialize testing environment: %s", err.Error())
+			klog.Fatalf("Unable to initialize testing environment: %s", err.Error())
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -163,9 +163,9 @@ func (helper *Helper) startAPIServer() {
 	helper.Env().Config.GRPCServer.DisableTLS = true
 	helper.APIServer = server.NewAPIServer(helper.EventBroadcaster)
 	go func() {
-		glog.V(10).Info("Test API server started")
+		klog.V(10).Info("Test API server started")
 		helper.APIServer.Start()
-		glog.V(10).Info("Test API server stopped")
+		klog.V(10).Info("Test API server stopped")
 	}()
 }
 
@@ -179,9 +179,9 @@ func (helper *Helper) stopAPIServer() error {
 func (helper *Helper) startMetricsServer() {
 	helper.MetricsServer = server.NewMetricsServer()
 	go func() {
-		glog.V(10).Info("Test Metrics server started")
+		klog.V(10).Info("Test Metrics server started")
 		helper.MetricsServer.Start()
-		glog.V(10).Info("Test Metrics server stopped")
+		klog.V(10).Info("Test Metrics server stopped")
 	}()
 }
 
@@ -195,9 +195,9 @@ func (helper *Helper) stopMetricsServer() error {
 func (helper *Helper) startHealthCheckServer() {
 	helper.HealthCheckServer = server.NewHealthCheckServer()
 	go func() {
-		glog.V(10).Info("Test health check server started")
+		klog.V(10).Info("Test health check server started")
 		helper.HealthCheckServer.Start()
-		glog.V(10).Info("Test health check server stopped")
+		klog.V(10).Info("Test health check server stopped")
 	}()
 }
 
@@ -218,17 +218,17 @@ func (helper *Helper) startEventServer(ctx context.Context) {
 	helper.Env().Config.PulseServer.SubscriptionType = "broadcast"
 	helper.EventServer = server.NewPulseServer(helper.EventBroadcaster)
 	go func() {
-		glog.V(10).Info("Test event server started")
+		klog.V(10).Info("Test event server started")
 		helper.EventServer.Start(ctx)
-		glog.V(10).Info("Test event server stopped")
+		klog.V(10).Info("Test event server stopped")
 	}()
 }
 
 func (helper *Helper) startEventBroadcaster() {
 	go func() {
-		glog.V(10).Info("Test event broadcaster started")
+		klog.V(10).Info("Test event broadcaster started")
 		helper.EventBroadcaster.Start(helper.Ctx)
-		glog.V(10).Info("Test event broadcaster stopped")
+		klog.V(10).Info("Test event broadcaster stopped")
 	}()
 }
 
@@ -264,7 +264,7 @@ func (helper *Helper) StartWorkAgent(ctx context.Context, clusterName string, bu
 	// initilize the mqtt options
 	mqttOptions, err := mqtt.BuildMQTTOptionsFromFlags(helper.Env().Config.MessageBroker.MessageBrokerConfig)
 	if err != nil {
-		glog.Fatalf("Unable to build MQTT options: %s", err.Error())
+		klog.Fatalf("Unable to build MQTT options: %s", err.Error())
 	}
 
 	var workCodec generic.Codec[*workv1.ManifestWork]
@@ -283,7 +283,7 @@ func (helper *Helper) StartWorkAgent(ctx context.Context, clusterName string, bu
 		WithWorkClientWatcherStore(watcherStore).
 		NewAgentClientHolder(ctx)
 	if err != nil {
-		glog.Fatalf("Unable to create work agent holder: %s", err)
+		klog.Fatalf("Unable to create work agent holder: %s", err)
 	}
 
 	factory := workinformers.NewSharedInformerFactoryWithOptions(
@@ -314,7 +314,7 @@ func (helper *Helper) StartGRPCResourceSourceClient() {
 	)
 
 	if err != nil {
-		glog.Fatalf("Unable to create grpc cloudevents source client: %s", err.Error())
+		klog.Fatalf("Unable to create grpc cloudevents source client: %s", err.Error())
 	}
 
 	sourceClient.Subscribe(helper.Ctx, func(action types.ResourceAction, resource *api.Resource) error {
@@ -328,31 +328,31 @@ func (helper *Helper) StartGRPCResourceSourceClient() {
 func (helper *Helper) RestartServer() {
 	helper.stopAPIServer()
 	helper.startAPIServer()
-	glog.V(10).Info("Test API server restarted")
+	klog.V(10).Info("Test API server restarted")
 }
 
 func (helper *Helper) RestartMetricsServer() {
 	helper.stopMetricsServer()
 	helper.startMetricsServer()
-	glog.V(10).Info("Test metrics server restarted")
+	klog.V(10).Info("Test metrics server restarted")
 }
 
 func (helper *Helper) Reset() {
-	glog.Infof("Reseting testing environment")
+	klog.Infof("Reseting testing environment")
 	env := environments.Environment()
 	// Reset the configuration
 	env.Config = config.NewApplicationConfig()
 
 	// Re-read command-line configuration into a NEW flagset
 	// This new flag set ensures we don't hit conflicts defining the same flag twice
-	// Also on reset, we don't care to be re-defining 'v' and other glog flags
+	// Also on reset, we don't care to be re-defining 'v' and other klog flags
 	flagset := pflag.NewFlagSet(helper.NewID(), pflag.ContinueOnError)
 	env.AddFlags(flagset)
 	pflag.Parse()
 
 	err := env.Initialize()
 	if err != nil {
-		glog.Fatalf("Unable to reset testing environment: %s", err.Error())
+		klog.Fatalf("Unable to reset testing environment: %s", err.Error())
 	}
 	helper.AppConfig = env.Config
 	helper.RestartServer()

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -6,14 +6,13 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/golang/glog"
-
 	"github.com/openshift-online/maestro/test"
+	"k8s.io/klog/v2"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	glog.Infof("Starting integration test using go version %s", runtime.Version())
+	klog.Infof("Starting integration test using go version %s", runtime.Version())
 	helper := test.NewHelper(&testing.T{})
 	exitCode := m.Run()
 	helper.Teardown()


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-14209

This PR introduces the following changes:

- Replaces `glog` with `klog`
Note: Maestro still indirectly depends on `glog` due to the current dependencies on `github.com/openshift-online/ocm-sdk-go` and `github.com/openshift-online/ocm-common`, which use `glog`.
- Configures `klog` to use `zapr` as the backing logger.
This setup enables enhanced logging features, including detailed timestamps and structured log output (e.g., `JSON` format).
- Refines the flags for the root command and subcommands to ensure they are correctly set.

Before this PR:

```
$ kc -n maestro logs deploy/maestro | head -3
I0826 16:01:43.167516       1 logger.go:103]  Received event from channel [status_events] : ffc0317d-4f73-4826-b9c9-1cebd3a4197f
I0826 16:01:43.186375       1 logger.go:103]  Broadcast the resource status 0d555480-f93b-57da-aab0-1269547348ac
I0826 16:01:43.236294       1 logger.go:103]  Broadcast the resource status fc396131-dc49-5587-9564-70f49d853a1a
```

After this PR:

```bash
$ kc -n maestro logs deploy/maestro | head -20
2024-09-12T08:40:06.976Z	INFO	environments/framework.go:79	Initializing development environment
2024-09-12T08:40:06.981Z	INFO	environments/framework.go:165	Using Mock OCM Authz Client
2024-09-12T08:40:06.993Z	LEVEL(-3)	cert/cert_rotation.go:56	Starting client certificate rotation controller
2024-09-12T08:40:06.999Z	INFO	clientcmd/client_config.go:659	Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2024-09-12T08:40:06.999Z	INFO	environments/framework.go:243	Disabling Sentry error reporting
2024-09-12T08:40:07.000Z	INFO	servecmd/cmd.go:49	Setting up pulse server
2024-09-12T08:40:07.002Z	INFO	server/grpc_server.go:113	Serving gRPC service with TLS at 8090
2024-09-12T08:40:07.002Z	LEVEL(-5)	channelz/logging.go:31	[core] [Server #1]Server created

2024-09-12T08:40:07.002Z	DEBUG	logger/logger.go:103	 Kind controller handling events
2024-09-12T08:40:07.002Z	DEBUG	logger/logger.go:103	 Status controller handling events
2024-09-12T08:40:07.002Z	INFO	server/healthcheck_server.go:53	Serving HealthCheck with TLS at 8083
2024-09-12T08:40:07.002Z	DEBUG	logger/logger.go:103	 Starting event controller
2024-09-12T08:40:07.002Z	DEBUG	logger/logger.go:103	 Starting pulse server
2024-09-12T08:40:07.002Z	LEVEL(-10)	logger/logger.go:103	 Checking liveness of maestro instances
2024-09-12T08:40:07.003Z	INFO	server/api_server.go:148	Serving with TLS at 8000
2024-09-12T08:40:07.003Z	INFO	event/event.go:75	Starting event broadcaster
2024-09-12T08:40:07.003Z	DEBUG	logger/logger.go:103	 Kind controller listening for events
2024-09-12T08:40:07.003Z	DEBUG	logger/logger.go:103	 Status controller listening for status events
2024-09-12T08:40:07.003Z	DEBUG	logger/logger.go:103	 Serving Metrics without TLS at 8080
```