### PR TITLE
enhance log level and environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ mqtt_client_cert ?= ""
 mqtt_client_key ?= ""
 
 # Log verbosity level
-klog_v:=10
+klog_v:=4
 
 # Location of the JSON web key set used to verify tokens:
 jwks_url:=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
@@ -144,11 +144,11 @@ GOLANGCI_LINT_BIN:=$(shell go env GOPATH)/bin/golangci-lint
 ### Envrionment-sourced variables with defaults
 # Can be overriden by setting environment var before running
 # Example:
-#   OCM_ENV=testing make run
-#   export OCM_ENV=testing; make run
+#   MAESTRO_ENV=testing make run
+#   export MAESTRO_ENV=testing; make run
 # Set the environment to development by default
-ifndef OCM_ENV
-	OCM_ENV:=development
+ifndef MAESTRO_ENV
+	MAESTRO_ENV:=development
 endif
 
 ifndef TEST_SUMMARY_FORMAT
@@ -221,7 +221,7 @@ install: check-gopath
 # Examples:
 #   make test TESTFLAGS="-run TestSomething"
 test:
-	OCM_ENV=testing gotestsum --jsonfile-timing-events=$(unit_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -v $(TESTFLAGS) \
+	MAESTRO_ENV=testing gotestsum --jsonfile-timing-events=$(unit_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -v $(TESTFLAGS) \
 		./pkg/... \
 		./cmd/...
 .PHONY: test
@@ -240,12 +240,12 @@ test-integration: test-integration-mqtt test-integration-grpc
 .PHONY: test-integration
 
 test-integration-mqtt:
-	BROKER=mqtt OCM_ENV=testing gotestsum --jsonfile-timing-events=$(mqtt_integration_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout 1h $(TESTFLAGS) \
+	BROKER=mqtt MAESTRO_ENV=testing gotestsum --jsonfile-timing-events=$(mqtt_integration_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout 1h $(TESTFLAGS) \
 			./test/integration
 .PHONY: test-integration-mqtt
 
 test-integration-grpc:
-	BROKER=grpc OCM_ENV=testing gotestsum --jsonfile-timing-events=$(grpc_integration_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout 1h $(TESTFLAGS) \
+	BROKER=grpc MAESTRO_ENV=testing gotestsum --jsonfile-timing-events=$(grpc_integration_test_json_output) --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout 1h $(TESTFLAGS) \
 			./test/integration
 .PHONY: test-integration-grpc
 
@@ -295,7 +295,7 @@ cmds:
 		--filename="templates/$*-template.yml" \
 		--local="true" \
 		--ignore-unknown-parameters="true" \
-		--param="ENVIRONMENT=$(OCM_ENV)" \
+		--param="ENVIRONMENT=$(MAESTRO_ENV)" \
 		--param="KLOG_V=$(klog_v)" \
 		--param="SERVER_REPLICAS=$(SERVER_REPLICAS)" \
 		--param="DATABASE_HOST=$(db_host)" \

--- a/cmd/maestro/environments/types.go
+++ b/cmd/maestro/environments/types.go
@@ -16,7 +16,7 @@ const (
 	DevelopmentEnv string = "development"
 	ProductionEnv  string = "production"
 
-	EnvironmentStringKey string = "OCM_ENV"
+	EnvironmentStringKey string = "MAESTRO_ENV"
 	EnvironmentDefault   string = DevelopmentEnv
 )
 

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -51,6 +51,12 @@ func main() {
 
 		// zap log level is the inverse of klog log level, for more details refer to:
 		// https://github.com/go-logr/zapr?tab=readme-ov-file#increasing-verbosity
+		// zap level mapping to klog level:
+		// fatal: -5, panic: -4, dpanic: -3, error: -2, warn: -1, info: 0, debug: 1
+		// the higher the log level, the more verbose the logs:
+		// if the log level is 0, it will log everything except debug logs;
+		// if the log level is 1, it will log everything including debug logs;
+		// if the log level is 2 or higher, it will log everything including klog verbose logs.
 		zc.Level = zap.NewAtomicLevelAt(zapcore.Level(0 - logLevel))
 		// Disable stacktrace for production environment
 		zc.DisableStacktrace = true

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -58,7 +58,7 @@ func main() {
 		// if the log level is 1, it will log everything including debug logs;
 		// if the log level is 2 or higher, it will log everything including klog verbose logs.
 		zc.Level = zap.NewAtomicLevelAt(zapcore.Level(0 - logLevel))
-		// Disable stacktrace for production environment
+		// Disable stacktrace to reduce logs size
 		zc.DisableStacktrace = true
 		zapLog, err := zc.Build()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	open-cluster-management.io/api v0.15.1-0.20241210025410-0ba6809d0ae2
 	open-cluster-management.io/ocm v0.15.1-0.20250108154653-2397c4e91119
-	open-cluster-management.io/sdk-go v0.15.1-0.20250212140629-c9cbca9e52cb
+	open-cluster-management.io/sdk-go v0.15.1-0.20250217031345-04acb74ee5ae
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -893,8 +893,8 @@ open-cluster-management.io/api v0.15.1-0.20241210025410-0ba6809d0ae2 h1:zkp3VJnv
 open-cluster-management.io/api v0.15.1-0.20241210025410-0ba6809d0ae2/go.mod h1:9erZEWEn4bEqh0nIX2wA7f/s3KCuFycQdBrPrRzi0QM=
 open-cluster-management.io/ocm v0.15.1-0.20250108154653-2397c4e91119 h1:Ftx7vxDumTB9d4+ZdcqYwQavTOVzgF5h6vAXJ/gh0IE=
 open-cluster-management.io/ocm v0.15.1-0.20250108154653-2397c4e91119/go.mod h1:T9pfSm3EYHnysEP9JYfCojV2pI44IYMz3zaZNylulz8=
-open-cluster-management.io/sdk-go v0.15.1-0.20250212140629-c9cbca9e52cb h1:w8ZV4DTTyIeRPR9OIgdNGLtC4YGmfSaq9lZeiJd7qZI=
-open-cluster-management.io/sdk-go v0.15.1-0.20250212140629-c9cbca9e52cb/go.mod h1:fi5WBsbC5K3txKb8eRLuP0Sim/Oqz/PHX18skAEyjiA=
+open-cluster-management.io/sdk-go v0.15.1-0.20250217031345-04acb74ee5ae h1:jxNiZbTXMFbdLUIFiowpSCSegXPWfGML0jlaEBCnq5o=
+open-cluster-management.io/sdk-go v0.15.1-0.20250217031345-04acb74ee5ae/go.mod h1:fi5WBsbC5K3txKb8eRLuP0Sim/Oqz/PHX18skAEyjiA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsAtVhSeUFseziht227YAWYHLGNM8QPwY=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.3 h1:XO2GvC9OPftRst6xWCpTgBZO04S2cbp0Qqkj8bX1sPw=

--- a/templates/agent-template-aro-hcp.yml
+++ b/templates/agent-template-aro-hcp.yml
@@ -14,6 +14,11 @@ labels:
   template: maestro-agent
 parameters:
 
+- name: ENVIRONMENT
+  displayName: Environment
+  description: Which maestro environment to use for this deployment
+  value: production
+
 - name: AGENT_NAMESPACE
   description: namespace of maestro agent
 
@@ -32,6 +37,11 @@ parameters:
 - name: IMAGE_TAG
   displayName: Image tag
   value: latest
+
+- name: KLOG_V
+  displayName: KLOG V Level
+  description: Log verbosity level
+  value: "1"
 
 objects:
 - apiVersion: apiextensions.k8s.io/v1
@@ -271,7 +281,10 @@ objects:
             - --workload-source-driver=mqtt
             - --workload-source-config=/secrets/mqtt/config.yaml
             - --cloudevents-client-id=$(CONSUMER_NAME)-work-agent
+            - -v=${KLOG_V}
           env:
+          - name: "MAESTRO_ENV"
+            value: "${ENVIRONMENT}"
           - name: CONSUMER_NAME
             valueFrom:
               secretKeyRef:

--- a/templates/agent-template-aro-hcp.yml
+++ b/templates/agent-template-aro-hcp.yml
@@ -41,7 +41,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "1"
+  value: "3"
 
 objects:
 - apiVersion: apiextensions.k8s.io/v1

--- a/templates/agent-template-aro-hcp.yml
+++ b/templates/agent-template-aro-hcp.yml
@@ -41,7 +41,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "3"
+  value: "4"
 
 objects:
 - apiVersion: apiextensions.k8s.io/v1

--- a/templates/agent-template-rosa.yml
+++ b/templates/agent-template-rosa.yml
@@ -14,6 +14,11 @@ labels:
   template: maestro-agent
 parameters:
 
+- name: ENVIRONMENT
+  displayName: Environment
+  description: Which maestro environment to use for this deployment
+  value: production
+
 - name: AGENT_NAMESPACE
   description: namespace of maestro agent
 
@@ -33,13 +38,13 @@ parameters:
   displayName: Image tag
   value: latest
 
-- name: MQTT_HOST
-  description: Hostname for the mqtt broker
-
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
   value: "4"
+
+- name: MQTT_HOST
+  description: Hostname for the mqtt broker.
 
 objects:
 - apiVersion: apiextensions.k8s.io/v1
@@ -273,6 +278,9 @@ objects:
         - name: maestro-agent
           image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: "MAESTRO_ENV"
+              value: "${ENVIRONMENT}"
           command:
             - /usr/local/bin/maestro
             - agent

--- a/templates/agent-template.yml
+++ b/templates/agent-template.yml
@@ -41,7 +41,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "1"
+  value: "3"
 
 - name: MESSAGE_DRIVER_TYPE
   displayName: Message Driver Type

--- a/templates/agent-template.yml
+++ b/templates/agent-template.yml
@@ -14,6 +14,11 @@ labels:
   template: maestro-agent
 parameters:
 
+- name: ENVIRONMENT
+  displayName: Environment
+  description: Which maestro environment to use for this deployment
+  value: production
+
 - name: AGENT_NAMESPACE
   description: namespace of maestro agent
 
@@ -32,6 +37,11 @@ parameters:
 - name: IMAGE_TAG
   displayName: Image tag
   value: latest
+
+- name: KLOG_V
+  displayName: KLOG V Level
+  description: Log verbosity level
+  value: "1"
 
 - name: MESSAGE_DRIVER_TYPE
   displayName: Message Driver Type
@@ -290,6 +300,9 @@ objects:
         - name: maestro-agent
           image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: "MAESTRO_ENV"
+              value: "${ENVIRONMENT}"
           command:
             - /usr/local/bin/maestro
             - agent
@@ -297,6 +310,7 @@ objects:
             - --workload-source-driver=${MESSAGE_DRIVER_TYPE}
             - --workload-source-config=/secrets/${MESSAGE_DRIVER_TYPE}/config.yaml
             - --cloudevents-client-id=${CONSUMER_NAME}-work-agent
+            - -v=${KLOG_V}
           volumeMounts:
           - name: ${MESSAGE_DRIVER_TYPE}
             mountPath: /secrets/${MESSAGE_DRIVER_TYPE}

--- a/templates/agent-template.yml
+++ b/templates/agent-template.yml
@@ -41,7 +41,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "3"
+  value: "4"
 
 - name: MESSAGE_DRIVER_TYPE
   displayName: Message Driver Type

--- a/templates/agent-tls-template.yml
+++ b/templates/agent-tls-template.yml
@@ -14,6 +14,11 @@ labels:
   template: maestro-agent
 parameters:
 
+- name: ENVIRONMENT
+  displayName: Environment
+  description: Which maestro environment to use for this deployment
+  value: production
+
 - name: AGENT_NAMESPACE
   description: namespace of maestro agent
 
@@ -32,6 +37,11 @@ parameters:
 - name: IMAGE_TAG
   displayName: Image tag
   value: latest
+
+- name: KLOG_V
+  displayName: KLOG V Level
+  description: Log verbosity level
+  value: "4"
 
 - name: MESSAGE_DRIVER_TYPE
   displayName: Message Driver Type
@@ -290,6 +300,9 @@ objects:
         - name: maestro-agent
           image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: "MAESTRO_ENV"
+              value: "${ENVIRONMENT}"
           command:
             - /usr/local/bin/maestro
             - agent
@@ -298,6 +311,7 @@ objects:
             - --workload-source-config=/secrets/${MESSAGE_DRIVER_TYPE}/config.yaml
             - --cloudevents-client-id=${CONSUMER_NAME}-work-agent
             - --appliedmanifestwork-eviction-grace-period=30s
+            - -v=${KLOG_V}
           volumeMounts:
           - name: ${MESSAGE_DRIVER_TYPE}
             mountPath: /secrets/${MESSAGE_DRIVER_TYPE}

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -38,7 +38,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "1"
+  value: "3"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -38,7 +38,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "3"
+  value: "4"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: ENVIRONMENT
   displayName: Environment
-  description: Which Account Manager environment to use for this deployment
+  description: Which maestro environment to use for this deployment
   value: production
 
 - name: IMAGE_REGISTRY
@@ -38,7 +38,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "10"
+  value: "1"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -231,7 +231,7 @@ objects:
               mountPath: /secrets/mqtt-creds
               readOnly: true
             env:
-              - name: "AMS_ENV"
+              - name: "MAESTRO_ENV"
                 value: "${ENVIRONMENT}"
               - name: POD_NAME
                 valueFrom:

--- a/templates/service-template-rosa.yml
+++ b/templates/service-template-rosa.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: ENVIRONMENT
   displayName: Environment
-  description: Which Account Manager environment to use for this deployment
+  description: Which maestro environment to use for this deployment
   value: production
 
 - name: IMAGE_REGISTRY
@@ -213,7 +213,7 @@ objects:
               mountPath: /secrets/mqtt-creds
               readOnly: true
             env:
-              - name: "AMS_ENV"
+              - name: "MAESTRO_ENV"
                 value: "${ENVIRONMENT}"
               - name: POD_NAME
                 valueFrom:

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -47,7 +47,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "1"
+  value: "3"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: ENVIRONMENT
   displayName: Environment
-  description: Which Account Manager environment to use for this deployment
+  description: Which maestro environment to use for this deployment
   value: production
 
 - name: IMAGE_REGISTRY
@@ -47,7 +47,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "10"
+  value: "1"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -324,7 +324,7 @@ objects:
             - name: authentication
               mountPath: /configs/authentication
             env:
-              - name: "AMS_ENV"
+              - name: "MAESTRO_ENV"
                 value: "${ENVIRONMENT}"
               - name: POD_NAME
                 valueFrom:

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -47,7 +47,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "3"
+  value: "4"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -415,7 +415,7 @@ objects:
         app: maestro
         port: api
       annotations:
-        description: Exposes and load balances the account manager pods
+        description: Exposes and load balances the maestro pods
         service.alpha.openshift.io/serving-cert-secret-name: maestro-tls
     spec:
       selector:

--- a/templates/service-tls-template.yml
+++ b/templates/service-tls-template.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: ENVIRONMENT
   displayName: Environment
-  description: Which Account Manager environment to use for this deployment
+  description: Which maestro environment to use for this deployment
   value: production
 
 - name: IMAGE_REGISTRY
@@ -34,7 +34,7 @@ parameters:
 - name: KLOG_V
   displayName: KLOG V Level
   description: Log verbosity level
-  value: "10"
+  value: "4"
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -366,7 +366,7 @@ objects:
             - name: maestro-grpc-cert
               mountPath: /secrets/maestro-grpc-cert
             env:
-              - name: "AMS_ENV"
+              - name: "MAESTRO_ENV"
                 value: "${ENVIRONMENT}"
               - name: POD_NAME
                 valueFrom:
@@ -460,7 +460,7 @@ objects:
         app: maestro
         port: api
       annotations:
-        description: Exposes and load balances the account manager pods
+        description: Exposes and load balances the maestro pods
         service.alpha.openshift.io/serving-cert-secret-name: maestro-tls
     spec:
       selector:

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -186,10 +186,28 @@ func TestResourcePost(t *testing.T) {
 		families := getServerMetrics(t, "http://localhost:8080/metrics")
 		labels := []*prommodel.LabelPair{
 			{Name: strPtr("source"), Value: strPtr("maestro")},
+			{Name: strPtr("original_source"), Value: strPtr("none")},
 			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
 			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceSpec))},
 			{Name: strPtr("action"), Value: strPtr("create_request")},
+		}
+		checkServerCounterMetric(t, families, "cloudevents_sent_total", labels, 1.0)
+		labels = []*prommodel.LabelPair{
+			{Name: strPtr("source"), Value: strPtr("maestro")},
+			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
+			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
+			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceSpec))},
+			{Name: strPtr("action"), Value: strPtr("create_request")},
+		}
+		checkServerCounterMetric(t, families, "cloudevents_received_total", labels, 1.0)
+		labels = []*prommodel.LabelPair{
+			{Name: strPtr("source"), Value: strPtr(clusterName)},
+			{Name: strPtr("original_source"), Value: strPtr("maestro")},
+			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
+			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
+			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceStatus))},
+			{Name: strPtr("action"), Value: strPtr("update_request")},
 		}
 		checkServerCounterMetric(t, families, "cloudevents_sent_total", labels, 1.0)
 		labels = []*prommodel.LabelPair{
@@ -824,6 +842,7 @@ func TestResourceFromGRPC(t *testing.T) {
 	if h.Broker != "grpc" {
 		labels = []*prommodel.LabelPair{
 			{Name: strPtr("source"), Value: strPtr("maestro")},
+			{Name: strPtr("original_source"), Value: strPtr("none")},
 			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
 			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceSpec))},
@@ -832,6 +851,7 @@ func TestResourceFromGRPC(t *testing.T) {
 		checkServerCounterMetric(t, families, "cloudevents_sent_total", labels, 2.0)
 		labels = []*prommodel.LabelPair{
 			{Name: strPtr("source"), Value: strPtr("maestro")},
+			{Name: strPtr("original_source"), Value: strPtr("none")},
 			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
 			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceSpec))},
@@ -840,6 +860,7 @@ func TestResourceFromGRPC(t *testing.T) {
 		checkServerCounterMetric(t, families, "cloudevents_sent_total", labels, 2.0)
 		labels = []*prommodel.LabelPair{
 			{Name: strPtr("source"), Value: strPtr("maestro")},
+			{Name: strPtr("original_source"), Value: strPtr("none")},
 			{Name: strPtr("cluster"), Value: strPtr(clusterName)},
 			{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 			{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceSpec))},

--- a/test/integration/status_dispatcher_test.go
+++ b/test/integration/status_dispatcher_test.go
@@ -67,6 +67,7 @@ func TestStatusDispatcher(t *testing.T) {
 	families := getServerMetrics(t, "http://localhost:8080/metrics")
 	labels := []*prommodel.LabelPair{
 		{Name: strPtr("source"), Value: strPtr("maestro")},
+		{Name: strPtr("original_source"), Value: strPtr("none")},
 		{Name: strPtr("cluster"), Value: strPtr(consumer1)},
 		{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 		{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceStatus))},
@@ -75,6 +76,7 @@ func TestStatusDispatcher(t *testing.T) {
 	checkServerCounterMetric(t, families, "cloudevents_sent_total", labels, 1.0)
 	labels = []*prommodel.LabelPair{
 		{Name: strPtr("source"), Value: strPtr("maestro")},
+		{Name: strPtr("original_source"), Value: strPtr("none")},
 		{Name: strPtr("cluster"), Value: strPtr(consumer2)},
 		{Name: strPtr("type"), Value: strPtr("io.open-cluster-management.works.v1alpha1.manifestbundles")},
 		{Name: strPtr("subresource"), Value: strPtr(string(types.SubResourceStatus))},


### PR DESCRIPTION
Support consistent environment settings for maestro agent with maestro server.
Changed default log level to 4, so that cloudevents will be printed for debug.