### PR TITLE
Downgrade ubuntu to 22.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
           container_tool: docker
           SERVER_REPLICAS: 2
   e2e-broadcast-subscription:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           SERVER_REPLICAS: 2
           ENABLE_BROADCAST_SUBSCRIPTION: true
   e2e-grpc-broker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
refer to https://github.com/actions/runner-images/issues/10636
> Breaking changes
Ubuntu 24.04 is ready to be the default version for the "ubuntu-latest" label in GitHub Actions and Azure DevOps.

> Target date
This change will be rolled out over a period of several weeks beginning December 5th and will complete on January 17th, 2025.

> OpenShift CLI 	latest available 	- 	Removed from the Ubuntu 24.04 image due to maintenance reasons.

In our tests, we are using `oc` command which is provided by Ubuntu image. The `oc` command is not available on Ubuntu 24.04. Currently, there is no problem in this repository because the change has not been rolled out in this area yet. However, it could be impacted eventually after January 17th. I noticed that this issue has already affected https://github.com/stolostron/maestro/pull/20