### PR TITLE
fix(migration): add last_heartbet and ready as column  of server_instances tables in a separate migration

### DIFF
--- a/pkg/db/migrations/202401151014_add_server_instances.go
+++ b/pkg/db/migrations/202401151014_add_server_instances.go
@@ -1,8 +1,6 @@
 package migrations
 
 import (
-	"time"
-
 	"gorm.io/gorm"
 
 	"github.com/go-gormigrate/gormigrate/v2"
@@ -11,8 +9,6 @@ import (
 func addServerInstances() *gormigrate.Migration {
 	type ServerInstance struct {
 		Model
-		LastHeartbeat time.Time
-		Ready         bool `gorm:"default:false"`
 	}
 
 	return &gormigrate.Migration{

--- a/pkg/db/migrations/202412171429_add_last_heartbeat_and_ready_column_in_server_instances_tables.go
+++ b/pkg/db/migrations/202412171429_add_last_heartbeat_and_ready_column_in_server_instances_tables.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+)
+
+func addLastHeartBeatAndReadyColumnInServerInstancesTable() *gormigrate.Migration {
+	type ServerInstance struct {
+		LastHeartbeat time.Time
+		Ready         bool `gorm:"default:false"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "202412171429",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&ServerInstance{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Migrator().DropColumn(&ServerInstance{}, "ready")
+			if err != nil {
+				return err
+			}
+			return tx.Migrator().DropColumn(&ServerInstance{}, "last_heartbeat")
+		},
+	}
+}

--- a/pkg/db/migrations/migration_structs.go
+++ b/pkg/db/migrations/migration_structs.go
@@ -34,6 +34,7 @@ var MigrationList = []*gormigrate.Migration{
 	addServerInstances(),
 	addStatusEvents(),
 	addEventInstances(),
+	addLastHeartBeatAndReadyColumnInServerInstancesTable(),
 }
 
 // Model represents the base model struct. All entities will have this struct embedded.


### PR DESCRIPTION
fix(migration): add last_heartbet and ready as column  of server_instances tables in a separate migration

Addresses https://github.com/openshift-online/maestro/pull/229/files#r1888513628 as the issue is causing existing deployment to fail with errors like
```
2024-12-17T13:19:34.107Z	ERROR	server/healthcheck_server.go:115	Unable to create maestro instance: ERROR: column "last_heartbeat" of relation "server_instances" does not exist (SQLSTATE 42703)
github.com/openshift-online/maestro/cmd/maestro/server.(*HealthCheckServer).pulse
```

or

```
2024-12-17T13:19:54.339Z	ERROR	server/healthcheck_server.go:184	Unable to mark inactive maestro instances ([maestro-maestro-689869f6dd-5jsbs maestro-maestro-689869f6dd-6tgxq]): ERROR: column "ready" of relation "server_instances" does not exist (SQLSTATE 42703)
github.com/openshift-online/maestro/cmd/maestro/server.(*HealthCheckServer).checkInstances
```