### PR TITLE
Fix tests

### DIFF
--- a/pkg/db/db_session/test.go
+++ b/pkg/db/db_session/test.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 	"k8s.io/klog/v2"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/openshift-online/maestro/pkg/config"
 	"github.com/openshift-online/maestro/pkg/db"
 )
@@ -65,7 +67,7 @@ func (f *Test) Init(config *config.DatabaseConfig) {
 
 func initDatabase(config *config.DatabaseConfig, migrate func(db2 *gorm.DB) error) error {
 	// - Connect to `template1` DB
-	dbx, g2, cleanup := connect("template1", config)
+	dbx, g2, cleanup := connect(config)
 	defer cleanup()
 
 	for _, err := dbx.Exec(`select 1`); err != nil; {
@@ -78,7 +80,7 @@ func initDatabase(config *config.DatabaseConfig, migrate func(db2 *gorm.DB) erro
 
 func resetDB(config *config.DatabaseConfig) error {
 	// Reconnect to the default `postgres` database, so we can drop the existing db and recreate it
-	dbx, _, cleanup := connect("postgres", config)
+	dbx, _, cleanup := connect(config)
 	defer cleanup()
 
 	// Drop `all` connections to both `template1` and AMS DB, so it can be dropped and created
@@ -103,26 +105,23 @@ func resetDB(config *config.DatabaseConfig) error {
 }
 
 // connect to database specified by `name` and return connections + cleanup function
-func connect(name string, config *config.DatabaseConfig) (*sql.DB, *gorm.DB, func()) {
+func connect(config *config.DatabaseConfig) (*sql.DB, *gorm.DB, func()) {
 	var (
 		dbx *sql.DB
 		g2  *gorm.DB
 		err error
 	)
 
-	dbx, err = sql.Open(config.Dialect, config.ConnectionStringWithName(name, config.SSLMode != disable))
+	connConfig, err := pgx.ParseConfig(config.ConnectionString(config.SSLMode != disable))
 	if err != nil {
-		dbx, err = sql.Open(config.Dialect, config.ConnectionStringWithName(name, false))
-		if err != nil {
-			panic(fmt.Sprintf(
-				"SQL failed to connect to %s database %s with connection string: %s\nError: %s",
-				config.Dialect,
-				name,
-				config.LogSafeConnectionStringWithName(name, config.SSLMode != disable),
-				err.Error(),
-			))
-		}
+		panic(fmt.Sprintf(
+			"GORM failed to parse the connection string: %s\nError: %s",
+			config.LogSafeConnectionString(config.SSLMode != disable),
+			err.Error(),
+		))
 	}
+
+	dbx = stdlib.OpenDB(*connConfig, stdlib.OptionBeforeConnect(setPassword(config)))
 
 	// Connect GORM to use the same connection
 	conf := &gorm.Config{
@@ -174,7 +173,7 @@ func connectFactory(config *config.DatabaseConfig) (*sql.DB, *gorm.DB) {
 		dbx *sql.DB
 		g2  *gorm.DB
 	)
-	dbx, g2, _ = connect(config.Name, config)
+	dbx, g2, _ = connect(config)
 	dbx.SetMaxOpenConns(config.MaxOpenConnections)
 
 	return dbx, g2

--- a/pkg/db/db_session/test.go
+++ b/pkg/db/db_session/test.go
@@ -43,7 +43,7 @@ func NewTestFactory(config *config.DatabaseConfig) *Test {
 
 // Init will:
 // - initialize a template1 DB with migrations
-// - rebuild AMS DB from template1
+// - rebuild Maestro DB from template1
 // - return a new connection factory
 // Go includes database connection pooling in the platform. Gorm uses the same and provides a method to
 // clone a connection via New(), which is safe for use by concurrent Goroutines.
@@ -83,7 +83,7 @@ func resetDB(config *config.DatabaseConfig) error {
 	dbx, _, cleanup := connect("postgres", config)
 	defer cleanup()
 
-	// Drop `all` connections to both `template1` and AMS DB, so it can be dropped and created
+	// Drop `all` connections to both `template1` and Maestro DB, so it can be dropped and created
 	if err := dropConnections(dbx, "template1"); err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func resetDB(config *config.DatabaseConfig) error {
 		return err
 	}
 
-	// Rebuild AMS DB
+	// Rebuild Maestro DB
 	query := fmt.Sprintf("DROP DATABASE IF EXISTS %s", config.Name)
 	if _, err := dbx.Exec(query); err != nil {
 		return fmt.Errorf("SQL failed to DROP database %s: %s", config.Name, err.Error())
@@ -100,7 +100,7 @@ func resetDB(config *config.DatabaseConfig) error {
 	if _, err := dbx.Exec(query); err != nil {
 		return fmt.Errorf("SQL failed to CREATE database %s: %s", config.Name, err.Error())
 	}
-	// As `template1` had all migrations, so now AMS DB has them too!
+	// As `template1` had all migrations, so now Maestro DB has them too!
 	return nil
 }
 


### PR DESCRIPTION
We have a question about why the CI passes without this fix, but the local environment does not. The reason is that in the CI environment, PostgreSQL runs in a sidecar container, making it effectively part of the same environment as the test container. In this case, no password is required for the database connection. The following explanation elaborates on this behavior.
> Note 1: The PostgreSQL image sets up trust authentication locally so you may notice a password is not required when connecting from localhost (inside the same container). However, a password will be required if connecting from a different host/container.

from https://hub.docker.com/_/postgres