### PR TITLE
Recreate listener if error is occured

### DIFF
--- a/pkg/db/db_session/test.go
+++ b/pkg/db/db_session/test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lib/pq"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -215,6 +216,8 @@ func (f *Test) ResetDB() {
 	f.wasDisconnected = true
 }
 
-func (f *Test) NewListener(ctx context.Context, channel string, callback func(id string)) {
-	newListener(ctx, f.config, channel, callback)
+func (f *Test) NewListener(ctx context.Context, channel string, callback func(id string)) *pq.Listener {
+	listener := newListener(ctx, f.config, channel)
+	go waitForNotification(ctx, listener, f.config, channel, callback)
+	return listener
 }

--- a/pkg/db/session.go
+++ b/pkg/db/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 
 	"github.com/openshift-online/maestro/pkg/config"
@@ -16,5 +17,5 @@ type SessionFactory interface {
 	CheckConnection() error
 	Close() error
 	ResetDB()
-	NewListener(ctx context.Context, channel string, callback func(id string))
+	NewListener(ctx context.Context, channel string, callback func(id string)) *pq.Listener
 }

--- a/test/integration/db_listener_test.go
+++ b/test/integration/db_listener_test.go
@@ -1,0 +1,58 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift-online/maestro/test"
+)
+
+func TestWaitForNotification(t *testing.T) {
+	// it is used to check the result of the notification
+	result := make(chan string)
+
+	h, _ := test.RegisterIntegration(t)
+
+	account := h.NewRandAccount()
+	ctx, cancel := context.WithCancel(h.NewAuthenticatedContext(account))
+	defer func() {
+		cancel()
+	}()
+
+	g2 := h.Env().Database.SessionFactory.New(ctx)
+
+	listener := h.Env().Database.SessionFactory.NewListener(ctx, "events", func(id string) {
+		result <- id
+	})
+	var originalListenerId string
+	// find the original listener id in the pg_stat_activity table
+	g2.Raw("SELECT pid FROM pg_stat_activity WHERE query LIKE 'LISTEN%'").Scan(&originalListenerId)
+	if originalListenerId == "" {
+		t.Errorf("the original Listener was not recreated")
+	}
+
+	// Simulate an errListenerClosed and wait for the listener to be recreated
+	listener.Close()
+	time.Sleep(2 * time.Second)
+
+	var newListenerId string
+	g2.Raw("SELECT pid FROM pg_stat_activity WHERE query LIKE 'LISTEN%'").Scan(&newListenerId)
+	if newListenerId == "" {
+		t.Errorf("the new Listener was not created")
+	}
+
+	// Validate the listener was recreated
+	if originalListenerId == newListenerId {
+		t.Errorf("Listener was not recreated")
+	}
+	// send a notification to the new listener
+	g2.Exec("NOTIFY events, 'test'")
+
+	// wait for the notification to be received
+	time.Sleep(1 * time.Second)
+
+	if <-result != "test" {
+		t.Errorf("the notification was not received")
+	}
+}


### PR DESCRIPTION
recreate the listener when the notify is nil or there is an error for Ping()
here is the document for notify is nil
> A notification channel will remain open until Unlisten is called, though connection loss might
result in some notifications being lost.  To solve this problem, Listener sends
a nil pointer over the Notify channel any time the connection is re-established
following a connection loss.  The application can get information about the
state of the underlying connection by setting an event callback in the call to
NewListener.