### PR TITLE
Remove Notify listener for server instance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
           make e2e-test
         env:
           container_tool: docker
-          SERVER_REPLICAS: 2
+          SERVER_REPLICAS: 3
           ENABLE_BROADCAST_SUBSCRIPTION: true
   e2e-grpc-broker:
     runs-on: ubuntu-22.04

--- a/cmd/maestro/servecmd/cmd.go
+++ b/cmd/maestro/servecmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -64,7 +65,7 @@ func runServer(cmd *cobra.Command, args []string) {
 			statusDispatcher = dispatcher.NewNoopDispatcher(environments.Environment().Database.SessionFactory, environments.Environment().Clients.CloudEventsSource)
 		case config.BroadcastSubscriptionType:
 			statusDispatcher = dispatcher.NewHashDispatcher(environments.Environment().Config.MessageBroker.ClientID, environments.Environment().Database.SessionFactory,
-				environments.Environment().Clients.CloudEventsSource, environments.Environment().Config.EventServer.ConsistentHashConfig)
+				environments.Environment().Clients.CloudEventsSource, environments.Environment().Config.EventServer.ConsistentHashConfig, 5*time.Second)
 		default:
 			log.Errorf("Unsupported subscription type: %s", subscriptionType)
 		}

--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -82,7 +82,6 @@ func (s *HealthCheckServer) Start(ctx context.Context) {
 }
 
 func (s *HealthCheckServer) pulse(ctx context.Context) {
-	log.Debugf("Updating heartbeat for maestro instance: %s", s.instanceID)
 	// If there are multiple requests at the same time, it will cause the race conditions among these
 	// requests (read–modify–write), the advisory lock is used here to prevent the race conditions.
 	lockOwnerID, err := s.lockFactory.NewAdvisoryLock(ctx, s.instanceID, db.Instances)
@@ -120,7 +119,6 @@ func (s *HealthCheckServer) pulse(ctx context.Context) {
 }
 
 func (s *HealthCheckServer) checkInstances(ctx context.Context) {
-	log.Debugf("Checking liveness of maestro instances")
 	// lock the Instance with a fail-fast advisory lock context.
 	// this allows concurrent processing of many instances by one or more maestro instances exclusively.
 	lockOwnerID, acquired, err := s.lockFactory.NewNonBlockingLock(ctx, "maestro-instances-liveness-check", db.Instances)
@@ -181,7 +179,6 @@ func (s *HealthCheckServer) healthCheckHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if instance.Ready {
-		log.Debugf("Instance is ready")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`{"status": "ok"}`))
 		if err != nil {
@@ -190,7 +187,6 @@ func (s *HealthCheckServer) healthCheckHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	log.Infof("Instance not ready")
 	w.WriteHeader(http.StatusServiceUnavailable)
 	_, err = w.Write([]byte(`{"status": "not ready"}`))
 	if err != nil {

--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -152,14 +152,14 @@ func (s *HealthCheckServer) checkInstances(ctx context.Context) {
 	}
 
 	if len(activeInstanceIDs) > 0 {
-		// batch mark active instances, this will tigger status dispatcher to call onInstanceUp handler.
+		// batch mark active instances.
 		if err := s.instanceDao.MarkReadyByIDs(ctx, activeInstanceIDs); err != nil {
 			log.Errorf("Unable to mark active maestro instances (%s): %s", activeInstanceIDs, err.Error())
 		}
 	}
 
 	if len(inactiveInstanceIDs) > 0 {
-		// batch mark inactive instances, this will tigger status dispatcher to call onInstanceDown handler.
+		// batch mark inactive instances.
 		if err := s.instanceDao.MarkUnreadyByIDs(ctx, inactiveInstanceIDs); err != nil {
 			log.Errorf("Unable to mark inactive maestro instances (%s): %s", inactiveInstanceIDs, err.Error())
 		}

--- a/pkg/dao/instance.go
+++ b/pkg/dao/instance.go
@@ -2,8 +2,6 @@ package dao
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"gorm.io/gorm/clause"
@@ -69,10 +67,7 @@ func (d *sqlInstanceDao) MarkReadyByIDs(ctx context.Context, ids []string) error
 		db.MarkForRollback(ctx, err)
 		return err
 	}
-
-	// call pg_notify to notify the server_instances channel
-	notify := fmt.Sprintf("select pg_notify('%s', '%s')", "server_instances", fmt.Sprintf("ready:%s", strings.Join(ids, ",")))
-	return g2.Exec(notify).Error
+	return nil
 }
 
 func (d *sqlInstanceDao) MarkUnreadyByIDs(ctx context.Context, ids []string) error {
@@ -81,9 +76,7 @@ func (d *sqlInstanceDao) MarkUnreadyByIDs(ctx context.Context, ids []string) err
 		db.MarkForRollback(ctx, err)
 		return err
 	}
-	// call pg_notify to notify the server_instances channel
-	notify := fmt.Sprintf("select pg_notify('%s', '%s')", "server_instances", fmt.Sprintf("unready:%s", strings.Join(ids, ",")))
-	return g2.Exec(notify).Error
+	return nil
 }
 
 func (d *sqlInstanceDao) Delete(ctx context.Context, id string) error {

--- a/pkg/db/advisory_locks.go
+++ b/pkg/db/advisory_locks.go
@@ -103,7 +103,6 @@ func (f *AdvisoryLockFactory) NewAdvisoryLock(ctx context.Context, id string, lo
 		return *lock.uuid, fmt.Errorf(errMsg)
 	}
 
-	log.Debugf("Locked advisory lock id=%s type=%s - owner=%s", id, lockType, *lock.uuid)
 	f.lockStore.add(*lock.uuid, lock)
 	return *lock.uuid, nil
 }
@@ -125,7 +124,6 @@ func (f *AdvisoryLockFactory) NewNonBlockingLock(ctx context.Context, id string,
 		return *lock.uuid, false, fmt.Errorf(errMsg)
 	}
 
-	log.Debugf("Locked non blocking advisory lock id=%s type=%s - owner=%s", id, lockType, *lock.uuid)
 	f.lockStore.add(*lock.uuid, lock)
 	return *lock.uuid, acquired, nil
 }
@@ -176,7 +174,6 @@ func (f *AdvisoryLockFactory) Unlock(ctx context.Context, uuid string) {
 	UpdateAdvisoryLockCountMetric(lockType, "OK")
 	UpdateAdvisoryLockDurationMetric(lockType, "OK", lock.startTime)
 
-	log.Debugf("Unlocked lock id=%s type=%s - owner=%s", lockID, lockType, uuid)
 	f.lockStore.delete(uuid)
 }
 

--- a/pkg/db/db_session/default.go
+++ b/pkg/db/db_session/default.go
@@ -155,7 +155,6 @@ func waitForNotification(ctx context.Context, l *pq.Listener, dbConfig *config.D
 				l = newListener(ctx, dbConfig, channel)
 			}
 		case <-time.After(10 * time.Second):
-			log.Debugf("Received no events on channel [%s] during interval. Pinging source", channel)
 			if err := l.Ping(); err != nil {
 				log.Infof("recreate the listener due to ping failed, %s", err.Error())
 				l.Close()

--- a/pkg/db/db_session/default.go
+++ b/pkg/db/db_session/default.go
@@ -195,7 +195,7 @@ func newListener(ctx context.Context, dbConfig *config.DatabaseConfig, channel s
 func (f *Default) NewListener(ctx context.Context, channel string, callback func(id string)) *pq.Listener {
 	listener := newListener(ctx, f.config, channel)
 
-	log.Infof("Starting channeling monitor for %s", channel)
+	log.Infof("Starting listener for %s", channel)
 	go waitForNotification(ctx, listener, f.config, channel, callback)
 	return listener
 }

--- a/pkg/db/db_session/default.go
+++ b/pkg/db/db_session/default.go
@@ -141,7 +141,7 @@ func waitForNotification(ctx context.Context, l *pq.Listener, dbConfig *config.D
 	for {
 		select {
 		case <-ctx.Done():
-			log.Infof("Context cancelled, stopping channel monitor")
+			log.Infof("Context cancelled, stopping channel [%s] monitor", channel)
 			return
 		case n := <-l.Notify:
 			if n != nil {
@@ -149,13 +149,13 @@ func waitForNotification(ctx context.Context, l *pq.Listener, dbConfig *config.D
 				callback(n.Extra)
 			} else {
 				// nil notification means the connection was closed
-				log.Infof("recreate the listener due to the connection loss")
+				log.Infof("recreate the listener for channel [%s] due to the connection loss", channel)
 				l.Close()
 				// recreate the listener
 				l = newListener(ctx, dbConfig, channel)
 			}
 		case <-time.After(10 * time.Second):
-			log.Debugf("Received no events on channel during interval. Pinging source")
+			log.Debugf("Received no events on channel [%s] during interval. Pinging source", channel)
 			if err := l.Ping(); err != nil {
 				log.Infof("recreate the listener due to ping failed, %s", err.Error())
 				l.Close()

--- a/pkg/dispatcher/hash_dispatcher_test.go
+++ b/pkg/dispatcher/hash_dispatcher_test.go
@@ -1,0 +1,60 @@
+package dispatcher
+
+import (
+	"testing"
+
+	"github.com/buraksezer/consistent"
+	"github.com/google/uuid"
+
+	"github.com/openshift-online/maestro/pkg/api"
+)
+
+func TestHashDispatcher(t *testing.T) {
+	consistent := consistent.New(nil, consistent.Config{
+		PartitionCount:    7,
+		ReplicationFactor: 20,
+		Load:              1.5,
+		Hasher:            hasher{},
+	})
+	for _, member := range []string{"maestro-maestro-598fb77bf4-rht4s", "maestro-maestro-598fb77bf4-2fslb"} {
+		consistent.Add(&api.ServerInstance{
+			Meta: api.Meta{
+				ID: member,
+			},
+		})
+	}
+
+	var consumers []string
+	for i := 0; i < 100; i++ {
+		id := uuid.New().String()
+		consumers = append(consumers, id)
+	}
+
+	for _, consumer := range consumers {
+		instance := consistent.LocateKey([]byte(consumer)).String()
+		if instance == "" {
+			t.Fatalf("should locate to one instance for the consumer %s", consumer)
+		}
+	}
+	consistent.Add(&api.ServerInstance{
+		Meta: api.Meta{
+			ID: "maestro-maestro-598fb77bf4-b4znx",
+		},
+	})
+
+	for _, consumer := range consumers {
+		instance := consistent.LocateKey([]byte(consumer)).String()
+		if instance == "" {
+			t.Fatalf("should locate to one instance for the consumer %s", consumer)
+		}
+	}
+
+	consistent.Remove("maestro-maestro-598fb77bf4-rht4s")
+
+	for _, consumer := range consumers {
+		instance := consistent.LocateKey([]byte(consumer)).String()
+		if instance == "" {
+			t.Fatalf("should locate to one instance for the consumer %s", consumer)
+		}
+	}
+}

--- a/test/e2e/setup/e2e_setup.sh
+++ b/test/e2e/setup/e2e_setup.sh
@@ -131,6 +131,7 @@ export mqtt_client_key="/secrets/mqtt-certs/client.key"
 if [ -n "${ENABLE_BROADCAST_SUBSCRIPTION}" ] && [ "${ENABLE_BROADCAST_SUBSCRIPTION}" = "true" ]; then
   export subscription_type="broadcast"
   export agent_topic="sources/maestro/consumers/+/agentevents"
+  export SERVER_REPLICAS=3
 fi
 
 make deploy-secrets \

--- a/test/e2e/setup/e2e_setup.sh
+++ b/test/e2e/setup/e2e_setup.sh
@@ -131,7 +131,6 @@ export mqtt_client_key="/secrets/mqtt-certs/client.key"
 if [ -n "${ENABLE_BROADCAST_SUBSCRIPTION}" ] && [ "${ENABLE_BROADCAST_SUBSCRIPTION}" = "true" ]; then
   export subscription_type="broadcast"
   export agent_topic="sources/maestro/consumers/+/agentevents"
-  export SERVER_REPLICAS=3
 fi
 
 make deploy-secrets \

--- a/test/helper.go
+++ b/test/helper.go
@@ -152,6 +152,7 @@ func NewHelper(t *testing.T) *Helper {
 				helper.Env().Database.SessionFactory,
 				helper.Env().Clients.CloudEventsSource,
 				helper.Env().Config.EventServer.ConsistentHashConfig,
+				1*time.Second,
 			)
 			helper.EventServer = server.NewMessageQueueEventServer(helper.EventBroadcaster, helper.StatusDispatcher)
 			helper.EventFilter = controllers.NewLockBasedEventFilter(db.NewAdvisoryLockFactory(helper.Env().Database.SessionFactory))

--- a/test/integration/status_dispatcher_test.go
+++ b/test/integration/status_dispatcher_test.go
@@ -42,12 +42,12 @@ func TestStatusDispatcher(t *testing.T) {
 
 	// insert a new instance and healthcheck server will mark it as ready and then add it to the hash ring
 	instanceDao := dao.NewInstanceDao(&h.Env().Database.SessionFactory)
-	_, err = instanceDao.Create(ctx, &api.ServerInstance{
+	_, err = instanceDao.Replace(ctx, &api.ServerInstance{
 		Meta: api.Meta{
 			ID: "instance1",
 		},
 		LastHeartbeat: time.Now(),
-		Ready:         false,
+		Ready:         true,
 	})
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
fixed: https://issues.redhat.com/browse/ACM-20643

Remove notify/listener for the server_instance that is because 
- we found that sometimes the notify is sent out while the listener is not started, so that the channel message is missed.
- if the pod is in CrashLoopBackOff and gets restarted, the hash ring cannot be initialized since the status is no change.

Based on the above reasons, this PR is proposed to remove the notify/listener and use the existing loop to handle it per 5 seconds.

in this PR, also remove some unnecessary debug logs which can lead the logs overflow due to being full 