### PR TITLE
using sdk-go grpc

### DIFF
--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -60,7 +60,9 @@ func NewGRPCServer(resourceService services.ResourceService, eventBroadcaster *e
 		Timeout:          config.ServerPingTimeout,
 	}))
 
-	if !config.DisableTLS {
+	disableTLS := (config.TLSCertFile == "" && config.TLSKeyFile == "")
+
+	if !disableTLS {
 		// Check tls cert and key path path
 		if config.TLSCertFile == "" || config.TLSKeyFile == "" {
 			check(
@@ -127,7 +129,7 @@ func NewGRPCServer(resourceService services.ResourceService, eventBroadcaster *e
 		grpcServer:        grpc.NewServer(grpcServerOptions...),
 		eventBroadcaster:  eventBroadcaster,
 		resourceService:   resourceService,
-		disableAuthorizer: config.DisableTLS,
+		disableAuthorizer: disableTLS,
 		grpcAuthorizer:    grpcAuthorizer,
 		bindAddress:       env().Config.HTTPServer.Hostname + ":" + config.ServerBindPort,
 	}

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	open-cluster-management.io/api v0.16.2-0.20250506092504-9143e192a0a7
 	open-cluster-management.io/ocm v0.16.1-0.20250514070927-4eda44f2b9b7
-	open-cluster-management.io/sdk-go v0.16.1-0.20250428032116-875454003818
+	open-cluster-management.io/sdk-go v0.16.1-0.20250530024739-3724a1e691fe
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -915,8 +915,8 @@ open-cluster-management.io/api v0.16.2-0.20250506092504-9143e192a0a7 h1:UupwgKlX
 open-cluster-management.io/api v0.16.2-0.20250506092504-9143e192a0a7/go.mod h1:/OeqXycNBZQoe3WG6ghuWsMgsKGuMZrK8ZpsU6gWL0Y=
 open-cluster-management.io/ocm v0.16.1-0.20250514070927-4eda44f2b9b7 h1:C/TdAM6a0VaLa/XfGGZAez3kucx+SZfLC7wG9Nee+5g=
 open-cluster-management.io/ocm v0.16.1-0.20250514070927-4eda44f2b9b7/go.mod h1:qZ/zAHqo59ExlfsTRW5t4EJJtbHZ/owfuKqAOTg1mrw=
-open-cluster-management.io/sdk-go v0.16.1-0.20250428032116-875454003818 h1:b7HpdTpKPzLEoJ5UtrXCed1PjxaKOxEboJ+kG6FZudI=
-open-cluster-management.io/sdk-go v0.16.1-0.20250428032116-875454003818/go.mod h1:n89YVVoi5zm3KVpOyVMmTdD4rGOVSsykUtu7Ol3do3M=
+open-cluster-management.io/sdk-go v0.16.1-0.20250530024739-3724a1e691fe h1:Y0FNpLz9msY7iz59lQxV+p2pY9aid0nzQ3IOMYxjHiU=
+open-cluster-management.io/sdk-go v0.16.1-0.20250530024739-3724a1e691fe/go.mod h1:n89YVVoi5zm3KVpOyVMmTdD4rGOVSsykUtu7Ol3do3M=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.2 h1:/439OZVxoEc02psi1h4QO3bHzTgu49bb347Xp4gW1pc=

--- a/pkg/config/grpc_server.go
+++ b/pkg/config/grpc_server.go
@@ -53,6 +53,7 @@ func (s *GRPCServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.WriteBufferSize, "grpc-write-buffer-size", 32*1024, "gPRC write buffer size")
 	fs.IntVar(&s.ReadBufferSize, "grpc-read-buffer-size", 32*1024, "gPRC read buffer size")
 	fs.BoolVar(&s.DisableTLS, "disable-grpc-tls", false, "Disable TLS for gRPC server, default is false")
+	fs.MarkDeprecated("disable-grpc-tls", "this flag will be removed, using tls file flags to determine if tls enabled")
 	fs.StringVar(&s.TLSCertFile, "grpc-tls-cert-file", "", "The path to the tls.crt file")
 	fs.StringVar(&s.TLSKeyFile, "grpc-tls-key-file", "", "The path to the tls.key file")
 	fs.StringVar(&s.BrokerTLSCertFile, "grpc-broker-tls-cert-file", "", "The path to the broker tls.crt file")

--- a/templates/agent-tls-template.yml
+++ b/templates/agent-tls-template.yml
@@ -317,8 +317,8 @@ objects:
             mountPath: /secrets/${MESSAGE_DRIVER_TYPE}
           - name: mqtt-certs
             mountPath: /secrets/mqtt-certs
-          - name: grpc-broker-ca
-            mountPath: /configmaps/grpc-broker-ca
+          - name: grpc-broker-cert
+            mountPath: /secretes/grpc-broker-certs
         volumes:
         - name: ${MESSAGE_DRIVER_TYPE}
           secret:
@@ -326,9 +326,9 @@ objects:
         - name: mqtt-certs
           secret:
             secretName: maestro-agent-certs
-        - name: grpc-broker-ca
-          configMap:
-            name: maestro-grpc-broker-ca
+        - name: grpc-broker-cert
+          secret:
+            secretName: maestro-grpc-broker-cert
 
 - apiVersion: v1
   kind: Secret
@@ -337,7 +337,9 @@ objects:
   stringData:
     config.yaml: |
       url: maestro-grpc-broker.maestro.svc:8091
-      caFile: /configmaps/grpc-broker-ca/service-ca.crt
+      caFile: /secretes/grpc-broker-certs/ca.crt
+      clientCertFile: /secretes/grpc-broker-certs/client.crt
+      clientKeyFile: /secretes/grpc-broker-certs/client.key
 
 - apiVersion: v1
   kind: Secret

--- a/templates/route-template.yml
+++ b/templates/route-template.yml
@@ -26,33 +26,3 @@ objects:
     tls:
       termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
-
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    name: maestro-grpc
-    labels:
-      app: maestro-grpc
-  spec:
-    host: maestro-grpc.${EXTERNAL_APPS_DOMAIN}
-    to:
-      kind: Service
-      name: maestro-grpc
-    tls:
-      termination: passthrough
-      insecureEdgeTerminationPolicy: None
-
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    name: maestro-grpc-broker
-    labels:
-      app: maestro-grpc-broker
-  spec:
-    host: maestro-grpc-broker.${EXTERNAL_APPS_DOMAIN}
-    to:
-      kind: Service
-      name: maestro-grpc-broker
-    tls:
-      termination: passthrough 
-      insecureEdgeTerminationPolicy: None

--- a/templates/service-template-aro-hcp.yml
+++ b/templates/service-template-aro-hcp.yml
@@ -5,7 +5,7 @@ metadata:
   name: maestro-service
   annotations:
     openshift.io/display-name: maestro
-    description: Example Service API for the Unified Hybrid Cloud deployment
+    description: Example for Maestro ARO deployment
     tags: golang,uhc,service-delivery
     iconClass: icon-shadowman
     template.openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/service-template-rosa.yml
+++ b/templates/service-template-rosa.yml
@@ -5,7 +5,7 @@ metadata:
   name: maestro-service
   annotations:
     openshift.io/display-name: maestro
-    description: Example Service API for the Unified Hybrid Cloud deployment
+    description: Example for Maestro ROSA deployment
     tags: golang,uhc,service-delivery
     iconClass: icon-shadowman
     template.openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -5,7 +5,7 @@ metadata:
   name: maestro-service
   annotations:
     openshift.io/display-name: maestro
-    description: Example Service API for the Unified Hybrid Cloud deployment
+    description: Example for Maestro deployment
     tags: golang,uhc,service-delivery
     iconClass: icon-shadowman
     template.openshift.io/provider-display-name: Red Hat, Inc.
@@ -109,20 +109,10 @@ parameters:
   description: gRPC server bind port
   value: "8090"
 
-- name: GRPC_BROKER_BINDPORT
-  displayName: gRPC Broker Bindport
-  description: gRPC broker bind port
-  value: "8091"
-
 - name: MESSAGE_DRIVER_TYPE
   displayName: Message Driver Type
   description: Message driver type, mqtt or grpc.
   value: mqtt
-
-- name: DISABLE_GRPC_TLS
-  displayName: Disable gRPC TLS
-  description: Disable TLS for gRPC server
-  value: "false"
 
 - name: METRICS_SERVER_BINDPORT
   displayName: Metrics Server Bindport
@@ -272,9 +262,6 @@ objects:
           - name: grpc-server-tls
             secret:
               secretName: maestro-grpc-server-tls
-          - name: grpc-broker-tls
-            secret:
-              secretName: maestro-grpc-broker-tls
           - name: service
             secret:
               secretName: maestro
@@ -319,8 +306,6 @@ objects:
               mountPath: /secrets/tls
             - name: grpc-server-tls
               mountPath: /secrets/grpc-server-tls
-            - name: grpc-broker-tls
-              mountPath: /secrets/grpc-broker-tls
             - name: service
               mountPath: /secrets/service
             - name: rds
@@ -357,11 +342,6 @@ objects:
             - --https-cert-file=/secrets/tls/tls.crt
             - --https-key-file=/secrets/tls/tls.key
             - --enable-grpc-server=${ENABLE_GRPC_SERVER}
-            - --disable-grpc-tls=${DISABLE_GRPC_TLS}
-            - --grpc-tls-cert-file=/secrets/grpc-server-tls/tls.crt
-            - --grpc-tls-key-file=/secrets/grpc-server-tls/tls.key
-            - --grpc-broker-tls-cert-file=/secrets/grpc-broker-tls/tls.crt
-            - --grpc-broker-tls-key-file=/secrets/grpc-broker-tls/tls.key
             - --acl-file=/configs/authentication/acl.yml
             - --jwk-cert-file=/configs/authentication/jwks.json
             - --jwk-cert-url=${JWKS_URL}
@@ -370,7 +350,6 @@ objects:
             - --server-hostname=${HTTP_SERVER_HOSTNAME}
             - --http-server-bindport=${HTTP_SERVER_BINDPORT}
             - --grpc-server-bindport=${GRPC_SERVER_BINDPORT}
-            - --grpc-broker-bindport=${GRPC_BROKER_BINDPORT}
             - --health-check-server-bindport=${HEALTH_CHECK_SERVER_BINDPORT}
             - --enable-health-check-https=${ENABLE_HTTPS}
             - --db-max-open-connections=${DB_MAX_OPEN_CONNS}
@@ -456,8 +435,7 @@ objects:
         app: maestro
         port: grpc
       annotations:
-        description: Exposes and load balances the maestro pods grpc endpoint
-        service.alpha.openshift.io/serving-cert-secret-name: maestro-grpc-server-tls
+        description: Exposes the grpc service
     spec:
       selector:
         app: maestro
@@ -465,24 +443,6 @@ objects:
         - name: grpc
           port: 8090
           targetPort: 8090
-          protocol: TCP
-
-  - kind: Service
-    apiVersion: v1
-    metadata:
-      name: maestro-grpc-broker
-      labels:
-        app: maestro
-        port: grpc-broker
-      annotations:
-        description: Exposes and load balances the maestro pods grpc broker endpoint
-    spec:
-      selector:
-        app: maestro
-      ports:
-        - name: grpc-broker
-          port: 8091
-          targetPort: 8091
           protocol: TCP
 
   - apiVersion: v1

--- a/templates/service-tls-template.yml
+++ b/templates/service-tls-template.yml
@@ -5,7 +5,7 @@ metadata:
   name: maestro-service
   annotations:
     openshift.io/display-name: maestro
-    description: Example Service API for the Unified Hybrid Cloud deployment
+    description: Example for Maestro e2e deployment
     tags: golang,uhc,service-delivery
     iconClass: icon-shadowman
     template.openshift.io/provider-display-name: Red Hat, Inc.
@@ -308,7 +308,7 @@ objects:
               secretName: maestro-tls
           - name: grpc-broker-tls
             secret:
-              secretName: maestro-grpc-broker-tls
+              secretName: maestro-grpc-broker-cert
           - name: service
             secret:
               secretName: maestro
@@ -403,8 +403,9 @@ objects:
             - --disable-grpc-tls=${DISABLE_GRPC_TLS}
             - --grpc-authn-type=token
             - --grpc-broker-bindport=${GRPC_BROKER_BINDPORT}
-            - --grpc-broker-tls-cert-file=/secrets/grpc-broker-tls/tls.crt
-            - --grpc-broker-tls-key-file=/secrets/grpc-broker-tls/tls.key
+            - --grpc-broker-client-ca-file=/secrets/grpc-broker-tls/ca.crt
+            - --grpc-broker-tls-cert-file=/secrets/grpc-broker-tls/server.crt
+            - --grpc-broker-tls-key-file=/secrets/grpc-broker-tls/server.key
             - --grpc-server-bindport=${GRPC_SERVER_BINDPORT}
             - --grpc-client-ca-file=/secrets/maestro-grpc-cert/ca.crt
             - --grpc-tls-cert-file=/secrets/maestro-grpc-cert/server.crt

--- a/test/e2e/pkg/status_resync_test.go
+++ b/test/e2e/pkg/status_resync_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Status Resync After Restart", Ordered, Label("e2e-tests-status
 			}, metav1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			// delete the nginx deployment to tigger recreating
+			// delete the nginx deployment to trigger recreating
 			err = agentTestOpts.kubeClientSet.AppsV1().Deployments("default").Delete(ctx, deployName, metav1.DeleteOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/test/e2e/pkg/suite_test.go
+++ b/test/e2e/pkg/suite_test.go
@@ -153,7 +153,10 @@ var _ = BeforeSuite(func() {
 		grpcClientTokenSrt, err := serverTestOpts.kubeClientSet.CoreV1().Secrets(serverTestOpts.serverNamespace).Get(ctx, "grpc-client-token", metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		// set CAFile and Token for grpc authz
-		grpcOptions.Dialer.TLSConfig, err = cert.AutoLoadTLSConfig(grpcServerCAFile, "", "", nil)
+		certConfig := cert.CertConfig{CAFile: grpcServerCAFile}
+		err = certConfig.EmbedCerts()
+		Expect(err).To(Succeed())
+		grpcOptions.Dialer.TLSConfig, err = cert.AutoLoadTLSConfig(certConfig, nil, nil)
 		Expect(err).To(Succeed())
 		grpcOptions.Dialer.Token = string(grpcClientTokenSrt.Data["token"])
 		// create the clusterrole for grpc authz


### PR DESCRIPTION
1. using sdk-go to implement the grpc broker
2. enable the mtls in grpc e2e
3. deprecated `disable-grpc-tls` flag, using tls file flags to determine if tls enabled
4. remove the grpc broker enable from server template