### PR TITLE
Retrieve opID from request header if existed and add to trace context

### DIFF
--- a/pkg/logger/operationid_middleware.go
+++ b/pkg/logger/operationid_middleware.go
@@ -20,16 +20,24 @@ const OpIDHeader OperationIDKey = "X-Operation-ID"
 // Middleware wraps the given HTTP handler so that the details of the request are sent to the log.
 func OperationIDMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := WithOpID(r.Context())
-		span := trace.SpanFromContext(ctx)
-
-		opID, ok := ctx.Value(OpIDKey).(string)
-		if ok && len(opID) > 0 {
-			span.SetAttributes(operationIDAttribute(opID))
+		ctx := r.Context()
+		// Get operation ID from request header if existed
+		opID := r.Header.Get(string(OpIDHeader))
+		if opID != "" {
+			// Add operationID to context (override if existed)
+			ctx = context.WithValue(ctx, OpIDKey, opID)
+		} else {
+			// If no operationID from header, get it from context or generate a new one
+			ctx = WithOpID(r.Context())
+			opID, _ := ctx.Value(OpIDKey).(string)
 			w.Header().Set(string(OpIDHeader), opID)
 		}
 
-		// Add operation ID to sentry context
+		// Add operationID attribute to span
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(operationIDAttribute(opID))
+
+		// Add operationID to sentry context
 		if hub := sentry.GetHubFromContext(ctx); hub != nil {
 			hub.ConfigureScope(func(scope *sentry.Scope) {
 				scope.SetTag("operation_id", opID)
@@ -56,6 +64,7 @@ func GetOperationID(ctx context.Context) string {
 	return ""
 }
 
+// operationIDAttribute returns an otel attribute with operationID
 func operationIDAttribute(id string) attribute.KeyValue {
 	return attribute.String(strings.ToLower(string(OpIDKey)), id)
 }


### PR DESCRIPTION
Incoming requests to maestro server contain a unique operation ID
either in request header or context. This ID can be used for tracing
and debugging purposes. The opID is retrieved from header or context
and being added to otel span attributes for observability. In case,
opID doesn't exist, a new one will be generated.