### PR TITLE
Recreate watcher

### DIFF
--- a/pkg/client/cloudevents/grpcsource/watcherstore.go
+++ b/pkg/client/cloudevents/grpcsource/watcherstore.go
@@ -282,15 +282,7 @@ func (m *RESTFulAPIWatcherStore) registerWatcher(namespace string, labelSelector
 	defer m.Unlock()
 
 	watcher, ok := m.watchers[namespace]
-	if ok {
-		if watcher.isStopped() {
-			// delete the stopped watcher
-			delete(m.watchers, namespace)
-			watcher = nil
-			// recreate a new watcher and register it
-			watcher = newWorkWatcher(namespace, labelSelector)
-			m.watchers[namespace] = watcher
-		}
+	if ok && !watcher.isStopped() {
 		return watcher
 	}
 

--- a/pkg/client/cloudevents/grpcsource/watcherstore.go
+++ b/pkg/client/cloudevents/grpcsource/watcherstore.go
@@ -283,6 +283,14 @@ func (m *RESTFulAPIWatcherStore) registerWatcher(namespace string, labelSelector
 
 	watcher, ok := m.watchers[namespace]
 	if ok {
+		if watcher.isStopped() {
+			// delete the stopped watcher
+			delete(m.watchers, namespace)
+			watcher = nil
+			// recreate a new watcher and register it
+			watcher = newWorkWatcher(namespace, labelSelector)
+			m.watchers[namespace] = watcher
+		}
 		return watcher
 	}
 

--- a/test/e2e/pkg/sourceclient_test.go
+++ b/test/e2e/pkg/sourceclient_test.go
@@ -250,6 +250,74 @@ var _ = Describe("SourceWorkClient", Ordered, Label("e2e-tests-source-work-clien
 				return AssertWatchResult(result)
 			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 		})
+
+		It("should recreate stopped watchers", func() {
+			watcherClient, err := grpcsource.NewMaestroGRPCSourceWorkClient(
+				ctx,
+				apiClient,
+				grpcOptions,
+				sourceID,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("create first watcher for namespace")
+			firstWatcher, err := watcherClient.ManifestWorks(agentTestOpts.consumerName).Watch(watcherCtx, metav1.ListOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			firstResult := StartWatch(watcherCtx, firstWatcher)
+
+			By("create and process a work with first watcher")
+			workName := "watcher-test-work-" + rand.String(5)
+			work := NewManifestWork(workName)
+			_, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Create(ctx, work, metav1.CreateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// wait for work to be processed
+			<-time.After(3 * time.Second)
+
+			By("stop the first watcher")
+			firstWatcher.Stop()
+
+			// wait for watcher to be fully stopped
+			<-time.After(2 * time.Second)
+
+			By("create second watcher for same namespace after first watcher stopped")
+			secondWatcher, err := watcherClient.ManifestWorks(agentTestOpts.consumerName).Watch(watcherCtx, metav1.ListOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			secondResult := StartWatch(watcherCtx, secondWatcher)
+
+			By("verify second watcher can process events independently")
+			updateWork, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Get(ctx, workName, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			newWork := updateWork.DeepCopy()
+			newWork.Spec.Workload.Manifests = []workv1.Manifest{NewManifest(workName + "-updated")}
+			patchData, err := grpcsource.ToWorkPatch(updateWork, newWork)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Patch(ctx, workName, types.MergePatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// wait for update to be processed
+			<-time.After(3 * time.Second)
+
+			By("delete the work")
+			err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Delete(ctx, workName, metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("verify second watcher received events")
+			Eventually(func() error {
+				if len(secondResult.WatchedWorks) == 0 {
+					return fmt.Errorf("second watcher should have received events")
+				}
+				return nil
+			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+			By("verify watchers are independent - first watcher stopped, second continues")
+			Expect(len(firstResult.WatchedWorks)).Should(BeNumerically(">", 0), "first watcher should have processed initial events")
+			Expect(len(secondResult.WatchedWorks)).Should(BeNumerically(">", 0), "second watcher should have processed events after restart")
+
+			secondWatcher.Stop()
+		})
 	})
 
 	Context("List works with source work client", func() {

--- a/test/e2e/pkg/sourceclient_test.go
+++ b/test/e2e/pkg/sourceclient_test.go
@@ -286,21 +286,6 @@ var _ = Describe("SourceWorkClient", Ordered, Label("e2e-tests-source-work-clien
 			secondResult := StartWatch(watcherCtx, secondWatcher)
 
 			By("verify second watcher can process events independently")
-			updateWork, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Get(ctx, workName, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			newWork := updateWork.DeepCopy()
-			newWork.Spec.Workload.Manifests = []workv1.Manifest{NewManifest(workName + "-updated")}
-			patchData, err := grpcsource.ToWorkPatch(updateWork, newWork)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			_, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Patch(ctx, workName, types.MergePatchType, patchData, metav1.PatchOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// wait for update to be processed
-			<-time.After(3 * time.Second)
-
-			By("delete the work")
 			err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Delete(ctx, workName, metav1.DeleteOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-23937

Here is an example:
```
if !mgr.leadershipFlag.Raised() {
	if watcher != nil {
		watcher.Stop()
	}
	return
}

watcher, err = maestroManifestWorkClient.Watch(ctx, v1.ListOptions{})
if err != nil {
	mgr.logger.Error(ctx, "%v", err)
	return
}

```
Stop will stop the chans in the watch. When watch is called again, the old watcher will be removed and return a new one