### PR TITLE
avoid potential deadlock

### DIFF
--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -269,6 +269,8 @@ func (svr *GRPCServer) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 			case evt := <-heartbeatCh:
 				if err := subServer.Send(evt); err != nil {
 					log.Errorf("failed to send heartbeat: %v", err)
+					// Unblock producers (handler select) and exit heartbeat ticker.
+					cancel()
 					select {
 					case sendErrCh <- err:
 					default:
@@ -278,6 +280,8 @@ func (svr *GRPCServer) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 			case evt := <-eventCh:
 				if err := subServer.Send(evt); err != nil {
 					log.Errorf("failed to send event: %v", err)
+					// Unblock producers (handler select) and exit heartbeat ticker.
+					cancel()
 					select {
 					case sendErrCh <- err:
 					default:


### PR DESCRIPTION
cancel context on Send errors to unblock producers.