### PR TITLE
filter the work with delete status

### DIFF
--- a/test/e2e/pkg/sourceclient_test.go
+++ b/test/e2e/pkg/sourceclient_test.go
@@ -398,62 +398,136 @@ var _ = Describe("SourceWorkClient", Ordered, Label("e2e-tests-source-work-clien
 		})
 
 		It("list works with options", func() {
-			By("list all works")
-			works, err := sourceWorkClient.ManifestWorks(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, workName, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
-
-			By("list works by consumer name")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, workName, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
-
-			By("list works by nonexistent consumer")
-			works, err = sourceWorkClient.ManifestWorks("nonexistent").List(ctx, metav1.ListOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items)).ShouldNot(HaveOccurred())
-
-			By("list works with nonexistent labels")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "nonexistent=true",
+			By("list all works", func() {
+				works, err := sourceWorkClient.ManifestWorks(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(AssertWorks(expectedWorks, workName, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
 			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items)).ShouldNot(HaveOccurred())
 
-			By("list works with app label")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "app=test",
+			By("list works by consumer name", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(AssertWorks(expectedWorks, workName, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
 			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
 
-			By("list works without test env")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "app=test,env!=integration",
-			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, prodWorkName)).ShouldNot(HaveOccurred())
+			By("list works by nonexistent consumer", func() {
+				works, err := sourceWorkClient.ManifestWorks("nonexistent").List(ctx, metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks)).ShouldNot(HaveOccurred())
 
-			By("list works in prod and test env")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "env in (production, integration)",
 			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
 
-			By("list works in test env and val not in a and b")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "env=integration,val notin (a,b)",
+			By("list works with nonexistent labels", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "nonexistent=true",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks)).ShouldNot(HaveOccurred())
 			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, testWorkCName)).ShouldNot(HaveOccurred())
 
-			By("list works with val label")
-			works, err = sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
-				LabelSelector: "val",
+			By("list works with app label", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "app=test",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
 			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(AssertWorks(works.Items, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
+
+			By("list works without test env", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "app=test,env!=integration",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks, prodWorkName)).ShouldNot(HaveOccurred())
+			})
+
+			By("list works in prod and test env", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "env in (production, integration)",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks, prodWorkName, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
+			})
+
+			By("list works in test env and val not in a and b", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "env=integration,val notin (a,b)",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks, testWorkCName)).ShouldNot(HaveOccurred())
+			})
+
+			By("list works with val label", func() {
+				works, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).List(ctx, metav1.ListOptions{
+					LabelSelector: "val",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				var expectedWorks []workv1.ManifestWork
+				for _, work := range works.Items {
+					if work.DeletionTimestamp != nil {
+						continue
+					}
+					expectedWorks = append(expectedWorks, work)
+				}
+				Expect(AssertWorks(expectedWorks, testWorkAName, testWorkBName, testWorkCName)).ShouldNot(HaveOccurred())
+			})
 
 			// TODO support does not exist
 			// By("list works without val label")


### PR DESCRIPTION
The e2e sometimes failed as below:
```
 SourceWorkClient List works with source work client list works with options [e2e-tests-source-work-client]
/home/runner/work/maestro/maestro/test/e2e/pkg/sourceclient_test.go:400
{"level":"info","ts":1759027217.1690166,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 288a5d41-1052-433c-a417-9bbee8f9c2e9"}
{"level":"info","ts":1759027217.2616448,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 75e9431d-00fe-4656-82c7-8377fe922656"}
{"level":"info","ts":1759027217.3600261,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 17e211dc-54c3-482b-8d52-fe6f3a9db051"}
{"level":"info","ts":1759027217.489367,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 4e4f7e0f-a0c5-4024-8da9-995f82ef033f"}
ignore the label unmatched work hcp-underlay-usw3oasi-mgmt-1/work-lbtv8 from the watcher sourceclient-test2z92g/hcp-underlay-usw3oasi-mgmt-1
ignore the work hcp-underlay-usw3oasi-mgmt-1/work-lbtv8 from the watcher sourceclient-test2z92g/other
ignore the label unmatched work hcp-underlay-usw3oasi-mgmt-1/work-lbtv8 from the watcher sourceclient-test2z92g/hcp-underlay-usw3oasi-mgmt-1
{"level":"info","ts":1759027217.623462,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 7eebdebe-b84d-4afa-a5c3-845340cecd11"}
ignore the work hcp-underlay-usw3oasi-mgmt-1/work-productionncfxr from the watcher sourceclient-test2z92g/other
  STEP: list all works @ 09/28/25 02:40:22.655
  [FAILED] in [It] - /home/runner/work/maestro/maestro/test/e2e/pkg/sourceclient_test.go:404 @ 09/28/25 02:40:22.724
{"level":"info","ts":1759027222.7875195,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: eb653802-7e56-4c6c-825b-8911bcc1b074"}
{"level":"info","ts":1759027222.8762417,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: d192684e-0bb0-4819-9605-7fa27fabc5dc"}
{"level":"info","ts":1759027222.9983964,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 64525ef5-a3db-403e-9f38-52cf6fab6a61"}
ignore the label unmatched work hcp-underlay-usw3oasi-mgmt-1/work-lbtv8 from the watcher sourceclient-test2z92g/hcp-underlay-usw3oasi-mgmt-1
{"level":"info","ts":1759027223.2083418,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: de45656b-bc31-4b1a-b60d-807f621bb715"}
ignore the label unmatched work hcp-underlay-usw3oasi-mgmt-1/work-lbtv8 from the watcher sourceclient-test2z92g/hcp-underlay-usw3oasi-mgmt-1
{"level":"info","ts":1759027223.4041297,"logger":"fallback","caller":"protocol/protocol.go:93","msg":"publishing event with id: 39525f39-0a11-4c61-b9ba-38fa4c4a1cb7"}
• [FAILED] [9.015 seconds]
SourceWorkClient List works with source work client [It] list works with options [e2e-tests-source-work-client]
/home/runner/work/maestro/maestro/test/e2e/pkg/sourceclient_test.go:400
  [FAILED] Unexpected error:
      <*errors.errorString | 0xc000652060>: 
      expected map[work-integration-a-rhs8t:{} work-integration-b-d7967:{} work-integration-c-685d9:{} work-lbtv8:{} work-productionncfxr:{}], but got map[work-integration-a-rhs8t:{} work-integration-b-d7967:{} work-integration-c-685d9:{} work-jc24z:{} work-lbtv8:{} work-productionncfxr:{}]
      {
          s: "expected map[work-integration-a-rhs8t:{} work-integration-b-d7967:{} work-integration-c-685d9:{} work-lbtv8:{} work-productionncfxr:{}], but got map[work-integration-a-rhs8t:{} work-integration-b-d7967:{} work-integration-c-685d9:{} work-jc24z:{} work-lbtv8:{} work-productionncfxr:{}]",
      }
  occurred
  In [It] at: /home/runner/work/maestro/maestro/test/e2e/pkg/sourceclient_test.go:404 @ 09/28/25 02:40:22.724
```

from the logs we can see we got more work than the expected value. the reason may be caused by some works are under deleting so it added into the list 