### PR TITLE
ensure resource cleanup for e2e.

### DIFF
--- a/test/e2e/pkg/consumer_test.go
+++ b/test/e2e/pkg/consumer_test.go
@@ -16,27 +16,7 @@ var _ = Describe("Consumers", Ordered, Label("e2e-tests-consumers"), func() {
 		consumerA := openapi.Consumer{Name: openapi.PtrString(fmt.Sprintf("consumer-a-%s", rand.String(5)))}
 		consumerB := openapi.Consumer{Name: openapi.PtrString(fmt.Sprintf("consumer-b-%s", rand.String(5)))}
 
-		AfterAll(func() {
-			// delete the consumer
-			resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumerA.Id).Execute()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
-
-			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumerA.Id).Execute()
-			Expect(err.Error()).To(ContainSubstring("Not Found"))
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-
-			// delete the consumer
-			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumerB.Id).Execute()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
-
-			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumerB.Id).Execute()
-			Expect(err.Error()).To(ContainSubstring("Not Found"))
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-		})
-
-		It("create consumer", func() {
+		BeforeAll(func() {
 			// create a consumer
 			created, resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersPost(ctx).Consumer(consumerA).Execute()
 			Expect(err).To(Succeed())
@@ -60,6 +40,26 @@ var _ = Describe("Consumers", Ordered, Label("e2e-tests-consumers"), func() {
 			Expect(err).To(Succeed())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(got).NotTo(BeNil())
+		})
+
+		AfterAll(func() {
+			// delete the consumer
+			resp, err := apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumerA.Id).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumerA.Id).Execute()
+			Expect(err.Error()).To(ContainSubstring("Not Found"))
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			// delete the consumer
+			resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdDelete(ctx, *consumerB.Id).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+			_, resp, err = apiClient.DefaultApi.ApiMaestroV1ConsumersIdGet(ctx, *consumerB.Id).Execute()
+			Expect(err.Error()).To(ContainSubstring("Not Found"))
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		})
 
 		It("list consumers", func() {

--- a/test/e2e/pkg/grpc_test.go
+++ b/test/e2e/pkg/grpc_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,105 +27,83 @@ import (
 )
 
 var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
-	Context("GRPC API Tests", func() {
+	Context("GRPC PubSub Tests", func() {
+		var subscriberCtx context.Context
+		var subscriberCancel context.CancelFunc
 		deployName := fmt.Sprintf("nginx-%s", rand.String(5))
 		resourceID := uuid.NewString()
-		resourceBundleStatus := &api.ResourceBundleStatus{
-			ManifestBundleStatus: &payload.ManifestBundleStatus{},
-		}
+		subscribedResourceStatus := &SubscribedResourceStatus{}
 
-		It("subscribe to resource status with grpc client", func() {
-			go func() {
-				subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: sourceID})
-				if err != nil {
-					return
-				}
+		BeforeAll(func() {
+			subscriberCtx, subscriberCancel = context.WithCancel(ctx)
+			// start resource status subscribe
+			go startStatusSubscribe(subscriberCtx, sourceID, grpcClient, subscribedResourceStatus)
 
-				for {
-					pvEvt, err := subClient.Recv()
-					if err == io.EOF {
-						return
-					}
-					if err != nil {
-						return
-					}
-					evt, err := binding.ToEvent(ctx, grpcprotocol.NewMessage(pvEvt))
-					if err != nil {
-						continue
-					}
-
-					evtExtensions := evt.Context.GetExtensions()
-					resID, err := cetypes.ToString(evtExtensions[types.ExtensionResourceID])
-					if err != nil {
-						continue
-					}
-
-					if resID != resourceID {
-						continue
-					}
-
-					resourceVersion, err := cetypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
-					if err != nil {
-						continue
-					}
-					resourceBundleStatus.ObservedVersion = resourceVersion
-
-					if err := evt.DataAs(resourceBundleStatus.ManifestBundleStatus); err != nil {
-						continue
-					}
-				}
-			}()
-		})
-
-		It("publish a resource spec with grpc client", func() {
+			By("publish a resource create request with grpc client")
 			evt, err := helper.NewEvent(sourceID, "create_request", agentTestOpts.consumerName, resourceID, deployName, 1, 1)
 			Expect(err).ShouldNot(HaveOccurred())
 			pbEvt := &pbv1.CloudEvent{}
 			err = grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
-			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
+			Expect(err).To(BeNil(), "failed to convert cloudevent to protobuf")
 			_, err = grpcClient.Publish(ctx, &pbv1.PublishRequest{Event: pbEvt})
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("subscribe to the resource status with grpc client", func() {
+		AfterAll(func() {
+			By("publish a resource delete request with grpc client")
+			evt, err := helper.NewEvent(sourceID, "delete_request", agentTestOpts.consumerName, resourceID, deployName, 2, 2)
+			Expect(err).ShouldNot(HaveOccurred())
+			pbEvt := &pbv1.CloudEvent{}
+			err = grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
+			Expect(err).To(BeNil(), "failed to convert cloudevent to protobuf")
+			_, err = grpcClient.Publish(ctx, &pbv1.PublishRequest{Event: pbEvt})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("should subscribe to the resource deleted status with grpc client")
 			Eventually(func() error {
-				if resourceBundleStatus.ManifestBundleStatus == nil {
+				if subscribedResourceStatus == nil {
+					return fmt.Errorf("subscribedResourceStatus is nil")
+				}
+				if subscribedResourceStatus.ResourceID != resourceID {
+					return fmt.Errorf("resource status for resource %s not found", resourceID)
+				}
+				if subscribedResourceStatus.Status == nil {
 					return fmt.Errorf("resource status is empty")
 				}
-
-				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, "Applied") {
-					return fmt.Errorf("resource not applied")
+				resourceBundleStatus := subscribedResourceStatus.Status
+				if resourceBundleStatus.ManifestBundleStatus == nil {
+					return fmt.Errorf("resource bundle status is empty")
 				}
 
-				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, "Available") {
-					return fmt.Errorf("resource not Available")
-				}
-
-				if len(resourceBundleStatus.ManifestBundleStatus.ResourceStatus) != 1 {
-					return fmt.Errorf("unexpected number of resource status, expected 1, got %d", len(resourceBundleStatus.ManifestBundleStatus.ResourceStatus))
-				}
-
-				resourceStatus := resourceBundleStatus.ManifestBundleStatus.ResourceStatus[0]
-				if len(resourceStatus.StatusFeedbacks.Values) != 1 {
-					return fmt.Errorf("unexpected number of status feedbacks, expected 1, got %d", len(resourceStatus.StatusFeedbacks.Values))
-				}
-
-				value := resourceStatus.StatusFeedbacks.Values[0]
-				contentStatus := make(map[string]interface{})
-				if err := json.Unmarshal([]byte(*value.Value.JsonRaw), &contentStatus); err != nil {
-					return fmt.Errorf("failed to convert status feedback value to content status: %v", err)
-				}
-
-				replicas, ok := contentStatus["replicas"]
-				if !ok {
-					return fmt.Errorf("replicas not found in content status")
-				}
-
-				if replicas.(float64) != float64(1) {
-					return fmt.Errorf("unexpected replicas, expected 1, got %d", replicas)
+				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, common.ResourceDeleted) {
+					return fmt.Errorf("resource is not deleted")
 				}
 
 				return nil
+			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+
+			Eventually(func() error {
+				_, err := agentTestOpts.kubeClientSet.AppsV1().Deployments("default").Get(ctx, deployName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+				return fmt.Errorf("nginx deployment still exists")
+			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+
+			_, resp, err := apiClient.DefaultApi.ApiMaestroV1ResourceBundlesIdGet(ctx, resourceID).Execute()
+			Expect(err).To(HaveOccurred(), "Expected 404 error")
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			// stop the resource status subscriber
+			subscriberCancel()
+		})
+
+		It("should subscribe to the resource status with grpc client", func() {
+			Eventually(func() error {
+				return assertResourceStatus(subscribedResourceStatus, resourceID, 1)
 			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
@@ -159,45 +138,9 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("subscribe to the resource status with grpc client", func() {
+		It("should subscribe to the resource status with grpc client", func() {
 			Eventually(func() error {
-				if resourceBundleStatus.ManifestBundleStatus == nil {
-					return fmt.Errorf("resource status is empty")
-				}
-
-				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, "Applied") {
-					return fmt.Errorf("resource not applied")
-				}
-
-				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, "Available") {
-					return fmt.Errorf("resource not Available")
-				}
-
-				if len(resourceBundleStatus.ManifestBundleStatus.ResourceStatus) != 1 {
-					return fmt.Errorf("unexpected number of resource status, expected 1, got %d", len(resourceBundleStatus.ManifestBundleStatus.ResourceStatus))
-				}
-
-				resourceStatus := resourceBundleStatus.ManifestBundleStatus.ResourceStatus[0]
-				if len(resourceStatus.StatusFeedbacks.Values) != 1 {
-					return fmt.Errorf("unexpected number of status feedbacks, expected 1, got %d", len(resourceStatus.StatusFeedbacks.Values))
-				}
-
-				value := resourceStatus.StatusFeedbacks.Values[0]
-				contentStatus := make(map[string]interface{})
-				if err := json.Unmarshal([]byte(*value.Value.JsonRaw), &contentStatus); err != nil {
-					return fmt.Errorf("failed to convert status feedback value to content status: %v", err)
-				}
-
-				replicas, ok := contentStatus["replicas"]
-				if !ok {
-					return fmt.Errorf("replicas not found in content status")
-				}
-
-				if replicas.(float64) != float64(2) {
-					return fmt.Errorf("unexpected replicas, expected 2, got %d", replicas)
-				}
-
-				return nil
+				return assertResourceStatus(subscribedResourceStatus, resourceID, 2)
 			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
@@ -221,48 +164,94 @@ var _ = Describe("GRPC", Ordered, Label("e2e-tests-grpc"), func() {
 			Expect(*gotResource.Id).To(Equal(resourceID))
 			Expect(*gotResource.Version).To(Equal(int32(2)))
 		})
-
-		It("publish a resource delete with grpc client", func() {
-			evt, err := helper.NewEvent(sourceID, "delete_request", agentTestOpts.consumerName, resourceID, deployName, 2, 2)
-			Expect(err).ShouldNot(HaveOccurred())
-			pbEvt := &pbv1.CloudEvent{}
-			err = grpcprotocol.WritePBMessage(ctx, binding.ToMessage(evt), pbEvt)
-			Expect(err).To(BeNil(), "failed to convert spec from cloudevent to protobuf")
-			_, err = grpcClient.Publish(ctx, &pbv1.PublishRequest{Event: pbEvt})
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("subscribe to the resource status with grpc client", func() {
-			Eventually(func() error {
-				if resourceBundleStatus.ManifestBundleStatus == nil {
-					return fmt.Errorf("resource status is empty")
-				}
-
-				if !meta.IsStatusConditionTrue(resourceBundleStatus.ManifestBundleStatus.Conditions, common.ResourceDeleted) {
-					return fmt.Errorf("resource is not deleted")
-				}
-
-				return nil
-			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
-		})
-
-		It("get the deployment from cluster", func() {
-			Eventually(func() error {
-				_, err := agentTestOpts.kubeClientSet.AppsV1().Deployments("default").Get(ctx, deployName, metav1.GetOptions{})
-				if err != nil {
-					if errors.IsNotFound(err) {
-						return nil
-					}
-					return err
-				}
-				return fmt.Errorf("nginx deployment still exists")
-			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
-		})
-
-		It("check the resource via maestro api", func() {
-			_, resp, err := apiClient.DefaultApi.ApiMaestroV1ResourceBundlesIdGet(ctx, resourceID).Execute()
-			Expect(err).To(HaveOccurred(), "Expected 404 error")
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-		})
 	})
 })
+
+type SubscribedResourceStatus struct {
+	ResourceID string
+	Status     *api.ResourceBundleStatus
+}
+
+func startStatusSubscribe(ctx context.Context, sourceID string, grpcClient pbv1.CloudEventServiceClient, subscribedResourceStatus *SubscribedResourceStatus) {
+	subClient, err := grpcClient.Subscribe(ctx, &pbv1.SubscriptionRequest{Source: sourceID})
+	if err != nil {
+		return
+	}
+
+	for {
+		pvEvt, err := subClient.Recv()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			return
+		}
+		evt, err := binding.ToEvent(ctx, grpcprotocol.NewMessage(pvEvt))
+		if err != nil {
+			continue
+		}
+		evtExtensions := evt.Context.GetExtensions()
+		resID, err := cetypes.ToString(evtExtensions[types.ExtensionResourceID])
+		if err != nil {
+			continue
+		}
+		subscribedResourceStatus.ResourceID = resID
+		resourceVersion, err := cetypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
+		if err != nil {
+			continue
+		}
+		subscribedResourceStatus.Status = &api.ResourceBundleStatus{
+			ObservedVersion:      resourceVersion,
+			ManifestBundleStatus: &payload.ManifestBundleStatus{},
+		}
+		if err := evt.DataAs(subscribedResourceStatus.Status.ManifestBundleStatus); err != nil {
+			continue
+		}
+	}
+}
+
+func assertResourceStatus(subscribedResourceStatus *SubscribedResourceStatus, resourceID string, expectedReplicas int32) error {
+	if subscribedResourceStatus == nil {
+		return fmt.Errorf("subscribedResourceStatus is nil")
+	}
+	if subscribedResourceStatus.ResourceID != resourceID {
+		return fmt.Errorf("resource status for resource %s not found", resourceID)
+	}
+	if subscribedResourceStatus.Status == nil {
+		return fmt.Errorf("resource status is empty")
+	}
+	resourceBundleStatus := subscribedResourceStatus.Status
+	if !meta.IsStatusConditionTrue(resourceBundleStatus.Conditions, "Applied") {
+		return fmt.Errorf("resource not applied")
+	}
+
+	if !meta.IsStatusConditionTrue(resourceBundleStatus.Conditions, "Available") {
+		return fmt.Errorf("resource not Available")
+	}
+
+	if len(resourceBundleStatus.ResourceStatus) != 1 {
+		return fmt.Errorf("unexpected number of resource status, expected 1, got %d", len(resourceBundleStatus.ResourceStatus))
+	}
+
+	resourceStatus := resourceBundleStatus.ResourceStatus[0]
+	if len(resourceStatus.StatusFeedbacks.Values) != 1 {
+		return fmt.Errorf("unexpected number of status feedbacks, expected 1, got %d", len(resourceStatus.StatusFeedbacks.Values))
+	}
+
+	value := resourceStatus.StatusFeedbacks.Values[0]
+	contentStatus := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(*value.Value.JsonRaw), &contentStatus); err != nil {
+		return fmt.Errorf("failed to convert status feedback value to content status: %v", err)
+	}
+
+	replicas, ok := contentStatus["replicas"]
+	if !ok {
+		return fmt.Errorf("replicas not found in content status")
+	}
+
+	if int32(replicas.(float64)) != expectedReplicas {
+		return fmt.Errorf("unexpected replicas, expected %d, got %d", expectedReplicas, int32(replicas.(float64)))
+	}
+
+	return nil
+}

--- a/test/e2e/pkg/status_resync_test.go
+++ b/test/e2e/pkg/status_resync_test.go
@@ -21,7 +21,9 @@ var _ = Describe("Status Resync After Restart", Ordered, Label("e2e-tests-status
 		workName := fmt.Sprintf("work-%s", rand.String(5))
 		deployName := fmt.Sprintf("nginx-%s", rand.String(5))
 		work := helper.NewManifestWork(workName, deployName, deployName, 1)
-		It("create a resource with source work client", func() {
+
+		BeforeAll(func() {
+			By("create a resource with source work client")
 			_, err := sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Create(ctx, work, metav1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -158,7 +160,8 @@ var _ = Describe("Status Resync After Restart", Ordered, Label("e2e-tests-status
 			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
 		})
 
-		It("delete the resource with source work client", func() {
+		AfterAll(func() {
+			By("delete the resource with source work client")
 			// note: wait some time to ensure source work client is connected to the restarted maestro server
 			Eventually(func() error {
 				return sourceWorkClient.ManifestWorks(agentTestOpts.consumerName).Delete(ctx, workName, metav1.DeleteOptions{})
@@ -174,9 +177,8 @@ var _ = Describe("Status Resync After Restart", Ordered, Label("e2e-tests-status
 				}
 				return fmt.Errorf("nginx deployment still exists")
 			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
-		})
 
-		It("check the resource deletion via maestro api", func() {
+			By("check the resource deletion via maestro api")
 			Eventually(func() error {
 				search := fmt.Sprintf("consumer_name = '%s'", agentTestOpts.consumerName)
 				gotResourceList, resp, err := apiClient.DefaultApi.ApiMaestroV1ResourceBundlesGet(ctx).Search(search).Execute()


### PR DESCRIPTION
use `AfterAll` to clean up resources even if tests fail, preventing pollution of long-running environments.

/assign @clyang82 @hchenxa 

Signed-off-by: morvencao <lcao@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED