### PR TITLE
send header in grpc server for compatibility

### DIFF
--- a/cmd/maestro/server/grpc_server.go
+++ b/cmd/maestro/server/grpc_server.go
@@ -16,9 +16,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"k8s.io/klog/v2"
 	workpayload "open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/payload"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/constants"
 	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
 	grpcprotocol "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
@@ -269,6 +271,14 @@ func (svr *GRPCServer) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 		}
 	}
 
+	// Generate subscription ID and send header IMMEDIATELY, before any other operations
+	// This ensures the client receives the header as soon as possible after the stream is established
+	// This is compatibility with sdk-go v1 and v2 gRPC clients
+	clientID := uuid.NewString()
+	if err := subServer.SendHeader(metadata.Pairs(constants.GRPCSubscriptionIDKey, clientID)); err != nil {
+		return fmt.Errorf("failed to send subscription header for subID %s: %w", clientID, err)
+	}
+
 	ctx, cancel := context.WithCancel(subServer.Context())
 	defer cancel()
 
@@ -315,7 +325,7 @@ func (svr *GRPCServer) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 		}
 	}()
 
-	clientID := svr.eventBroadcaster.Register(ctx, subReq.Source, func(res *api.Resource) error {
+	svr.eventBroadcaster.Register(ctx, clientID, subReq.Source, func(res *api.Resource) error {
 		evt, err := encodeResourceStatus(res)
 		if err != nil {
 			return fmt.Errorf("failed to encode cloudevent: %v", err)

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,6 @@ open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf h1:SnLaZD2QH
 open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf/go.mod h1:ZpXs1bFTIIqKstMHdLO9IY0NFlbCvZgEtByvvNSmab0=
 open-cluster-management.io/ocm v1.2.1-0.20260310135001-19a386c0609b h1:ql7DNK7xoWYJTFhyUy/3KG64fjwj/TZBLCc9U1xyK9I=
 open-cluster-management.io/ocm v1.2.1-0.20260310135001-19a386c0609b/go.mod h1:NeXII90YZphP4T2jTPgt7uvrnQEnw5vcmmXmSQHVZms=
-open-cluster-management.io/sdk-go v1.2.1-0.20260310072111-3041045c0177 h1:8YzKbl+PuWIvTyU7C1pVuPUIY4cdbccv5BXZySQfDYI=
-open-cluster-management.io/sdk-go v1.2.1-0.20260310072111-3041045c0177/go.mod h1:lDef+5BvifXww0S7cseux+Wi8melkH29bAf33OZ0ZVg=
 open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b h1:C919NhpIzPJO8iKzvej5gRhZV5S5rapa/YCznkjUPcU=
 open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b/go.mod h1:lDef+5BvifXww0S7cseux+Wi8melkH29bAf33OZ0ZVg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/uuid"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/pkg/api"
@@ -38,14 +37,16 @@ func NewEventBroadcaster() *EventBroadcaster {
 	}
 }
 
-// Register registers a client and return client id and error channel.
-func (h *EventBroadcaster) Register(ctx context.Context, source string, handler resourceHandler) string {
+// Register registers a client with its ID.
+func (h *EventBroadcaster) Register(ctx context.Context,
+	id string,
+	source string,
+	handler resourceHandler) {
 	logger := klog.FromContext(ctx)
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	id := uuid.NewString()
 	h.clients[id] = &eventClient{
 		source:  source,
 		handler: handler,
@@ -53,11 +54,9 @@ func (h *EventBroadcaster) Register(ctx context.Context, source string, handler 
 
 	logger.Info("registered a broadcaster client", "id", id, "source", source)
 	grpcRegisteredSourceClientsGaugeMetric.WithLabelValues(source).Inc()
-
-	return id
 }
 
-// Unregister unregisters a client by id
+// Unregister unregisters a client by its ID.
 func (h *EventBroadcaster) Unregister(ctx context.Context, id string) {
 	logger := klog.FromContext(ctx).WithValues("id", id)
 	h.mu.Lock()


### PR DESCRIPTION
## What

Send a `subscription-id` header immediately at the start of the `Subscribe` stream in the Maestro gRPC server, and move client ID generation from `EventBroadcaster.Register` to the caller (`GRPCServer.Subscribe`).

## Why

sdk-go v2 gRPC client transport (`generic/options/v2/grpc/transport.go`) calls `subClient.Header()` immediately after `Subscribe()` and blocks until the server sends response headers. It then reads `subscription-id` from those headers to identify the connection. Without this header being sent upfront, the client blocks indefinitely waiting for a header that never arrives until the first event is sent.

This aligns the Maestro gRPC server with the pattern already used in the sdk-go `GRPCBroker` implementation (`server/grpc/broker.go`), which performs the same `SendHeader` → `Register` ordering.

## How

- Generate `clientID` (UUID) at the top of `Subscribe`, before any other operations.
- Call `subServer.SendHeader(metadata.Pairs(constants.GRPCSubscriptionIDKey, clientID))` immediately. Return an error if the header cannot be sent.
- Pass `clientID` explicitly to `eventBroadcaster.Register(...)` instead of generating it internally.
- Update `EventBroadcaster.Register` signature: drop internal UUID generation and the `string` return value; accept `id string` as a parameter. Update the doc comment accordingly.

The `SendHeader` → `Register` ordering is intentional: gRPC flushes response headers automatically on the first `Send` call. If `Register` were called first and a broadcast immediately triggered `Send`, the headers would be flushed without the `subscription-id` key.

## Testing

Existing integration and e2e tests cover the gRPC Subscribe path. A dedicated integration test asserting that `subscription-id` is present and is a valid UUID is tracked in `plan.md` and will be added in a follow-up.