### PR TITLE
Add one-command build/setup: Quick Start section in README [Generated by gurnben's Agent]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Maestro is a system to leverage [CloudEvents](https://cloudevents.io/) to transp
 - The Maestro server is responsible for storing the resources and their status. And sending the resources to the message broker in the CloudEvents format. The Maestro server provides Resful APIs and gRPC APIs to manage the resources.
 - Maestro agent is responsible for receiving the resources and applying them to the target clusters. And reporting back the status of the resources.
 
+## Quick Start
+
+```bash
+make db/setup       # Start local PostgreSQL
+make mqtt/setup     # Start local MQTT broker
+make binary         # Build the maestro binary
+make test           # Run unit tests
+make run            # Run migrations and start server
+```
+
 ## Architecture
 
 Taking MQTT as an example:


### PR DESCRIPTION
## Summary

Adds one-command build/setup capability to improve developer onboarding and AI-assisted development.

### Changes

- **README.md** — added Quick Start section with `make` commands in a prominent position


### Why this matters

[AgentReady](https://github.com/ambient-code/agentready) checks for two things in the One-Command Build/Setup attribute:

1. A build automation tool exists (Makefile, setup script, etc.)
2. The setup command is documented **prominently in the README** (within the first few sections)

This PR addresses the documentation requirement — the Makefile already exists but setup instructions were not prominently placed in the README.

## AgentReady Score Impact

| Metric | Value |
|--------|-------|
| **Current score** | **62.0/100** (Silver) |
| **This PR** | **+3 points** |
| **Score after this PR** | **65/100** (Silver) |

### Attribute addressed

- One-Command Build/Setup (+3) — Tier 2 (Critical)

## Testing

- [ ] No functional code changes — documentation only
- [ ] Existing Makefile targets still work

---

> :robot_face: *This PR was generated by an AI agent* ([Claude](https://claude.ai)) as part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`. The agent assessed all 32 public repositories using [AgentReady](https://github.com/ambient-code/agentready), identified improvement opportunities, generated the changes, and opened this PR. All commits are GPG-signed by [@gurnben](https://github.com/gurnben).
