### PR TITLE
ARO-26559 fix(cloudevents): send empty status hash list on resync to avoid MQTT 512KB packet limit

### DIFF
--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -14,7 +15,7 @@ import (
 	ceclients "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/clients"
 	cemetrics "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/metrics"
 	ceoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
-	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+	cepayload "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
 	cetypes "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 
 	"github.com/openshift-online/maestro/pkg/api"
@@ -36,6 +37,8 @@ type SourceClientImpl struct {
 	Codec                  cegeneric.Codec[*api.Resource]
 	CloudEventSourceClient *ceclients.CloudEventSourceClient[*api.Resource]
 	ResourceService        services.ResourceService
+	sourceID               string
+	transport              ceoptions.CloudEventTransport
 }
 
 func NewSourceClient(sourceOptions *ceoptions.CloudEventsSourceOptions, resourceService services.ResourceService) (SourceClient, error) {
@@ -54,6 +57,8 @@ func NewSourceClient(sourceOptions *ceoptions.CloudEventsSourceOptions, resource
 		Codec:                  codec,
 		CloudEventSourceClient: ceSourceClient,
 		ResourceService:        resourceService,
+		sourceID:               sourceOptions.SourceID,
+		transport:              sourceOptions.CloudEventsTransport,
 	}, nil
 }
 
@@ -158,12 +163,60 @@ func (s *SourceClientImpl) Resync(ctx context.Context, consumers []string) error
 
 	logger.Info("Resyncing resource status from consumers")
 	for _, consumer := range consumers {
-		if err := s.CloudEventSourceClient.Resync(ctx, consumer); err != nil {
+		if err := s.resyncConsumer(ctx, consumer); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// statusHashBatchSize is the maximum number of resources for which real status hashes are computed
+// during a resync. Resources beyond this limit are included in the payload with an empty hash,
+// which causes the agent to treat them as mismatched and re-publish their status unconditionally.
+// This bounds hash computation cost and message size for consumers with many resources.
+const statusHashBatchSize = 2000
+
+// resyncConsumer sends a status resync request to the consumer. Real hashes are computed for the
+// first statusHashBatchSize resources; remaining resources are included with an empty hash so the
+// agent re-publishes their status without the server needing to compute all hashes upfront.
+func (s *SourceClientImpl) resyncConsumer(ctx context.Context, consumer string) error {
+	objs, err := s.ResourceService.List(ctx, cetypes.ListOptions{
+		Source:              s.sourceID,
+		ClusterName:         consumer,
+		CloudEventsDataType: s.Codec.EventDataType(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list resources for consumer %s: %v", consumer, err)
+	}
+
+	hashes := make([]cepayload.ResourceStatusHash, len(objs))
+	for i, obj := range objs {
+		statusHash := ""
+		if i < statusHashBatchSize {
+			statusHash, err = ResourceStatusHashGetter(obj)
+			if err != nil {
+				return err
+			}
+		}
+		hashes[i] = cepayload.ResourceStatusHash{
+			ResourceID: string(obj.GetUID()),
+			StatusHash: statusHash,
+		}
+	}
+
+	eventType := cetypes.CloudEventsType{
+		CloudEventsDataType: s.Codec.EventDataType(),
+		SubResource:         cetypes.SubResourceStatus,
+		Action:              cetypes.ResyncRequestAction,
+	}
+
+	evt := cetypes.NewEventBuilder(s.sourceID, eventType).WithClusterName(consumer).NewEvent()
+	if err := evt.SetData(cloudevents.ApplicationJSON, &cepayload.ResourceStatusHashList{Hashes: hashes}); err != nil {
+		return fmt.Errorf("failed to set resync event data: %v", err)
+	}
+
+	return s.transport.Send(ctx, evt)
 }
 
 func (s *SourceClientImpl) SubscribedChan() <-chan struct{} {
@@ -186,7 +239,7 @@ func ResourceStatusHashGetter(res *api.Resource) (string, error) {
 	// retrieve stash hash from status CloudEvent extension;
 	// if not found, calculate the status hash by itself
 	evtExtensions := evt.Context.GetExtensions()
-	statusHashVal, ok := evtExtensions[types.ExtensionStatusHash]
+	statusHashVal, ok := evtExtensions[cetypes.ExtensionStatusHash]
 	if ok {
 		return fmt.Sprintf("%v", statusHashVal), nil
 	}

--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -171,40 +171,10 @@ func (s *SourceClientImpl) Resync(ctx context.Context, consumers []string) error
 	return nil
 }
 
-// statusHashBatchSize is the maximum number of resources for which real status hashes are computed
-// during a resync. Resources beyond this limit are included in the payload with an empty hash,
-// which causes the agent to treat them as mismatched and re-publish their status unconditionally.
-// This bounds hash computation cost and message size for consumers with many resources.
-const statusHashBatchSize = 2000
-
-// resyncConsumer sends a status resync request to the consumer. Real hashes are computed for the
-// first statusHashBatchSize resources; remaining resources are included with an empty hash so the
-// agent re-publishes their status without the server needing to compute all hashes upfront.
+// resyncConsumer sends a status resync request with an empty hash list to the consumer.
+// An empty list signals the agent to re-publish status for all its resources unconditionally,
+// keeping the outbound message small regardless of resource count.
 func (s *SourceClientImpl) resyncConsumer(ctx context.Context, consumer string) error {
-	objs, err := s.ResourceService.List(ctx, cetypes.ListOptions{
-		Source:              s.sourceID,
-		ClusterName:         consumer,
-		CloudEventsDataType: s.Codec.EventDataType(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list resources for consumer %s: %v", consumer, err)
-	}
-
-	hashes := make([]cepayload.ResourceStatusHash, len(objs))
-	for i, obj := range objs {
-		statusHash := ""
-		if i < statusHashBatchSize {
-			statusHash, err = ResourceStatusHashGetter(obj)
-			if err != nil {
-				return err
-			}
-		}
-		hashes[i] = cepayload.ResourceStatusHash{
-			ResourceID: string(obj.GetUID()),
-			StatusHash: statusHash,
-		}
-	}
-
 	eventType := cetypes.CloudEventsType{
 		CloudEventsDataType: s.Codec.EventDataType(),
 		SubResource:         cetypes.SubResourceStatus,
@@ -212,7 +182,7 @@ func (s *SourceClientImpl) resyncConsumer(ctx context.Context, consumer string) 
 	}
 
 	evt := cetypes.NewEventBuilder(s.sourceID, eventType).WithClusterName(consumer).NewEvent()
-	if err := evt.SetData(cloudevents.ApplicationJSON, &cepayload.ResourceStatusHashList{Hashes: hashes}); err != nil {
+	if err := evt.SetData(cloudevents.ApplicationJSON, &cepayload.ResourceStatusHashList{}); err != nil {
 		return fmt.Errorf("failed to set resync event data: %v", err)
 	}
 

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -20,7 +20,7 @@ func (m *mockTransport) Connect(_ context.Context) error                        
 func (m *mockTransport) Subscribe(_ context.Context) error                             { return nil }
 func (m *mockTransport) Receive(_ context.Context, _ ceoptions.ReceiveHandlerFn) error { return nil }
 func (m *mockTransport) Close(_ context.Context) error                                 { return nil }
-func (m *mockTransport) ErrorChan() <-chan error                                        { return nil }
+func (m *mockTransport) ErrorChan() <-chan error                                       { return nil }
 func (m *mockTransport) Send(_ context.Context, evt cloudevents.Event) error {
 	m.sentEvents = append(m.sentEvents, evt)
 	return nil

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -1,0 +1,255 @@
+package cloudevents
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	ceoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
+	cepayload "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
+	cetypes "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/errors"
+	"github.com/openshift-online/maestro/pkg/services"
+)
+
+// mockTransport captures sent events for assertion.
+type mockTransport struct {
+	sentEvents []cloudevents.Event
+}
+
+func (m *mockTransport) Connect(_ context.Context) error                              { return nil }
+func (m *mockTransport) Subscribe(_ context.Context) error                            { return nil }
+func (m *mockTransport) Receive(_ context.Context, _ ceoptions.ReceiveHandlerFn) error { return nil }
+func (m *mockTransport) Close(_ context.Context) error                                { return nil }
+func (m *mockTransport) ErrorChan() <-chan error                                      { return nil }
+func (m *mockTransport) Send(_ context.Context, evt cloudevents.Event) error {
+	m.sentEvents = append(m.sentEvents, evt)
+	return nil
+}
+
+// mockResourceService implements only the List method needed by resyncConsumer.
+type mockResourceService struct {
+	resources []*api.Resource
+	services.ResourceService
+}
+
+func (m *mockResourceService) List(_ context.Context, _ cetypes.ListOptions) ([]*api.Resource, error) {
+	return m.resources, nil
+}
+
+// Stub out the remaining interface methods to satisfy the compiler.
+func (m *mockResourceService) Get(_ context.Context, _ string) (*api.Resource, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) Create(_ context.Context, _ *api.Resource) (*api.Resource, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) Update(_ context.Context, _ *api.Resource) (*api.Resource, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) UpdateStatus(_ context.Context, _ *api.Resource) (*api.Resource, bool, *errors.ServiceError) {
+	return nil, false, nil
+}
+func (m *mockResourceService) MarkAsDeleting(_ context.Context, _ string) *errors.ServiceError {
+	return nil
+}
+func (m *mockResourceService) Delete(_ context.Context, _ string) *errors.ServiceError { return nil }
+func (m *mockResourceService) All(_ context.Context) (api.ResourceList, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) FindByIDs(_ context.Context, _ []string) (api.ResourceList, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) FindBySource(_ context.Context, _ string) (api.ResourceList, *errors.ServiceError) {
+	return nil, nil
+}
+func (m *mockResourceService) ListWithArgs(_ context.Context, _ string, _ *services.ListArguments, _ *[]api.Resource) (*api.PagingMeta, *errors.ServiceError) {
+	return nil, nil
+}
+
+// makeResources builds n resources with empty Status (no hash needed).
+func makeResources(n int) []*api.Resource {
+	resources := make([]*api.Resource, n)
+	for i := range resources {
+		resources[i] = &api.Resource{
+			Meta: api.Meta{ID: uuid.New().String()},
+		}
+	}
+	return resources
+}
+
+func newTestSourceClient(transport *mockTransport, resources []*api.Resource) *SourceClientImpl {
+	codec := NewCodec("test-source")
+	return &SourceClientImpl{
+		Codec:           codec,
+		ResourceService: &mockResourceService{resources: resources},
+		sourceID:        "test-source",
+		transport:       transport,
+	}
+}
+
+// decodeHashList decodes the ResourceStatusHashList from the first sent event.
+func decodeHashList(t *testing.T, transport *mockTransport) *cepayload.ResourceStatusHashList {
+	t.Helper()
+	if len(transport.sentEvents) == 0 {
+		t.Fatal("expected transport to have received an event, got none")
+	}
+	evt := transport.sentEvents[0]
+	list := &cepayload.ResourceStatusHashList{}
+	if err := json.Unmarshal(evt.Data(), list); err != nil {
+		t.Fatalf("failed to decode ResourceStatusHashList: %v", err)
+	}
+	return list
+}
+
+// TestResyncConsumerHashList verifies that resyncConsumer produces a hash list
+// where the first statusHashBatchSize entries have real (non-empty) hashes and
+// any remaining entries have an empty hash, forcing the agent to re-publish
+// their status unconditionally.
+func TestResyncConsumerHashList(t *testing.T) {
+	cases := []struct {
+		name            string
+		resourceCount   int
+		wantRealHashes  int
+		wantEmptyHashes int
+	}{
+		{"fewer than batch size", 10, 10, 0},
+		{"exactly batch size", statusHashBatchSize, statusHashBatchSize, 0},
+		{"over batch size", statusHashBatchSize + 500, statusHashBatchSize, 500},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			transport := &mockTransport{}
+			client := newTestSourceClient(transport, makeResources(c.resourceCount))
+
+			if err := client.resyncConsumer(context.Background(), "consumer-1"); err != nil {
+				t.Fatalf("resyncConsumer returned unexpected error: %v", err)
+			}
+
+			list := decodeHashList(t, transport)
+
+			if len(list.Hashes) != c.resourceCount {
+				t.Errorf("expected %d hash entries, got %d", c.resourceCount, len(list.Hashes))
+			}
+
+			realCount, emptyCount := 0, 0
+			for _, h := range list.Hashes {
+				if h.ResourceID == "" {
+					t.Error("found entry with empty ResourceID")
+				}
+				if h.StatusHash == "" {
+					emptyCount++
+				} else {
+					realCount++
+				}
+			}
+
+			if realCount != c.wantRealHashes {
+				t.Errorf("expected %d entries with real hashes, got %d", c.wantRealHashes, realCount)
+			}
+			if emptyCount != c.wantEmptyHashes {
+				t.Errorf("expected %d entries with empty hashes, got %d", c.wantEmptyHashes, emptyCount)
+			}
+		})
+	}
+}
+
+// TestResyncConsumer5000Resources verifies the hash list content and prints the
+// payload size when the consumer manages 5000 resources (well above the batch size).
+func TestResyncConsumer5000Resources(t *testing.T) {
+	const count = 5000
+	transport := &mockTransport{}
+	client := newTestSourceClient(transport, makeResources(count))
+
+	if err := client.resyncConsumer(context.Background(), "consumer-1"); err != nil {
+		t.Fatalf("resyncConsumer returned unexpected error: %v", err)
+	}
+
+	list := decodeHashList(t, transport)
+
+	if len(list.Hashes) != count {
+		t.Errorf("expected %d hash entries, got %d", count, len(list.Hashes))
+	}
+
+	realCount, emptyCount := 0, 0
+	for _, h := range list.Hashes {
+		if h.StatusHash == "" {
+			emptyCount++
+		} else {
+			realCount++
+		}
+	}
+
+	if realCount != statusHashBatchSize {
+		t.Errorf("expected %d real hashes, got %d", statusHashBatchSize, realCount)
+	}
+	if emptyCount != count-statusHashBatchSize {
+		t.Errorf("expected %d empty hashes, got %d", count-statusHashBatchSize, emptyCount)
+	}
+
+	evt := transport.sentEvents[0]
+
+	hashJSONSize := len(evt.Data())
+	t.Logf("hash JSON size:          %d bytes (%.1f KB)", hashJSONSize, float64(hashJSONSize)/1024)
+
+	fullEvent, err := evt.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal full CloudEvent: %v", err)
+	}
+	fullEventSize := len(fullEvent)
+	t.Logf("full CloudEvent size:    %d bytes (%.1f KB)", fullEventSize, float64(fullEventSize)/1024)
+	t.Logf("envelope overhead:       %d bytes", fullEventSize-hashJSONSize)
+}
+
+// TestResyncConsumerEventStructure verifies that resyncConsumer sends a correctly
+// formed CloudEvent — right type, source, and cluster name — regardless of whether
+// the hash list contains real or empty hashes.
+func TestResyncConsumerEventStructure(t *testing.T) {
+	const consumer = "cluster-abc"
+
+	transport := &mockTransport{}
+	client := newTestSourceClient(transport, makeResources(statusHashBatchSize+1))
+
+	if err := client.resyncConsumer(context.Background(), consumer); err != nil {
+		t.Fatalf("resyncConsumer returned unexpected error: %v", err)
+	}
+
+	if len(transport.sentEvents) != 1 {
+		t.Fatalf("expected 1 sent event, got %d", len(transport.sentEvents))
+	}
+
+	evt := transport.sentEvents[0]
+
+	if evt.Source() != "test-source" {
+		t.Errorf("expected source 'test-source', got %q", evt.Source())
+	}
+
+	wantType := cetypes.CloudEventsType{
+		CloudEventsDataType: NewCodec("test-source").EventDataType(),
+		SubResource:         cetypes.SubResourceStatus,
+		Action:              cetypes.ResyncRequestAction,
+	}
+	if evt.Type() != wantType.String() {
+		t.Errorf("expected event type %q, got %q", wantType.String(), evt.Type())
+	}
+
+	gotCluster, err := evt.Context.GetExtension(cetypes.ExtensionClusterName)
+	if err != nil {
+		t.Fatalf("missing clusterName extension: %v", err)
+	}
+	if gotCluster != consumer {
+		t.Errorf("expected clusterName %q, got %q", consumer, gotCluster)
+	}
+
+	// Confirm the last entry (beyond the batch) has an empty hash.
+	list := decodeHashList(t, transport)
+	last := list.Hashes[len(list.Hashes)-1]
+	if last.StatusHash != "" {
+		t.Errorf("expected last entry (beyond batch) to have empty StatusHash, got %q", last.StatusHash)
+	}
+}

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -6,14 +6,9 @@ import (
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/google/uuid"
 	ceoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	cepayload "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
 	cetypes "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
-
-	"github.com/openshift-online/maestro/pkg/api"
-	"github.com/openshift-online/maestro/pkg/errors"
-	"github.com/openshift-online/maestro/pkg/services"
 )
 
 // mockTransport captures sent events for assertion.
@@ -21,206 +16,87 @@ type mockTransport struct {
 	sentEvents []cloudevents.Event
 }
 
-func (m *mockTransport) Connect(_ context.Context) error                              { return nil }
-func (m *mockTransport) Subscribe(_ context.Context) error                            { return nil }
+func (m *mockTransport) Connect(_ context.Context) error                               { return nil }
+func (m *mockTransport) Subscribe(_ context.Context) error                             { return nil }
 func (m *mockTransport) Receive(_ context.Context, _ ceoptions.ReceiveHandlerFn) error { return nil }
-func (m *mockTransport) Close(_ context.Context) error                                { return nil }
-func (m *mockTransport) ErrorChan() <-chan error                                      { return nil }
+func (m *mockTransport) Close(_ context.Context) error                                 { return nil }
+func (m *mockTransport) ErrorChan() <-chan error                                        { return nil }
 func (m *mockTransport) Send(_ context.Context, evt cloudevents.Event) error {
 	m.sentEvents = append(m.sentEvents, evt)
 	return nil
 }
 
-// mockResourceService implements only the List method needed by resyncConsumer.
-type mockResourceService struct {
-	resources []*api.Resource
-	services.ResourceService
-}
-
-func (m *mockResourceService) List(_ context.Context, _ cetypes.ListOptions) ([]*api.Resource, error) {
-	return m.resources, nil
-}
-
-// Stub out the remaining interface methods to satisfy the compiler.
-func (m *mockResourceService) Get(_ context.Context, _ string) (*api.Resource, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) Create(_ context.Context, _ *api.Resource) (*api.Resource, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) Update(_ context.Context, _ *api.Resource) (*api.Resource, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) UpdateStatus(_ context.Context, _ *api.Resource) (*api.Resource, bool, *errors.ServiceError) {
-	return nil, false, nil
-}
-func (m *mockResourceService) MarkAsDeleting(_ context.Context, _ string) *errors.ServiceError {
-	return nil
-}
-func (m *mockResourceService) Delete(_ context.Context, _ string) *errors.ServiceError { return nil }
-func (m *mockResourceService) All(_ context.Context) (api.ResourceList, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) FindByIDs(_ context.Context, _ []string) (api.ResourceList, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) FindBySource(_ context.Context, _ string) (api.ResourceList, *errors.ServiceError) {
-	return nil, nil
-}
-func (m *mockResourceService) ListWithArgs(_ context.Context, _ string, _ *services.ListArguments, _ *[]api.Resource) (*api.PagingMeta, *errors.ServiceError) {
-	return nil, nil
-}
-
-// makeResources builds n resources with empty Status (no hash needed).
-func makeResources(n int) []*api.Resource {
-	resources := make([]*api.Resource, n)
-	for i := range resources {
-		resources[i] = &api.Resource{
-			Meta: api.Meta{ID: uuid.New().String()},
-		}
-	}
-	return resources
-}
-
-func newTestSourceClient(transport *mockTransport, resources []*api.Resource) *SourceClientImpl {
-	codec := NewCodec("test-source")
+func newTestSourceClient(transport *mockTransport) *SourceClientImpl {
 	return &SourceClientImpl{
-		Codec:           codec,
-		ResourceService: &mockResourceService{resources: resources},
-		sourceID:        "test-source",
-		transport:       transport,
+		Codec:     NewCodec("test-source"),
+		sourceID:  "test-source",
+		transport: transport,
 	}
 }
 
-// decodeHashList decodes the ResourceStatusHashList from the first sent event.
-func decodeHashList(t *testing.T, transport *mockTransport) *cepayload.ResourceStatusHashList {
-	t.Helper()
-	if len(transport.sentEvents) == 0 {
-		t.Fatal("expected transport to have received an event, got none")
-	}
-	evt := transport.sentEvents[0]
-	list := &cepayload.ResourceStatusHashList{}
-	if err := json.Unmarshal(evt.Data(), list); err != nil {
-		t.Fatalf("failed to decode ResourceStatusHashList: %v", err)
-	}
-	return list
-}
-
-// TestResyncConsumerHashList verifies that resyncConsumer produces a hash list
-// where the first statusHashBatchSize entries have real (non-empty) hashes and
-// any remaining entries have an empty hash, forcing the agent to re-publish
-// their status unconditionally.
-func TestResyncConsumerHashList(t *testing.T) {
-	cases := []struct {
-		name            string
-		resourceCount   int
-		wantRealHashes  int
-		wantEmptyHashes int
-	}{
-		{"fewer than batch size", 10, 10, 0},
-		{"exactly batch size", statusHashBatchSize, statusHashBatchSize, 0},
-		{"over batch size", statusHashBatchSize + 500, statusHashBatchSize, 500},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			transport := &mockTransport{}
-			client := newTestSourceClient(transport, makeResources(c.resourceCount))
-
-			if err := client.resyncConsumer(context.Background(), "consumer-1"); err != nil {
-				t.Fatalf("resyncConsumer returned unexpected error: %v", err)
-			}
-
-			list := decodeHashList(t, transport)
-
-			if len(list.Hashes) != c.resourceCount {
-				t.Errorf("expected %d hash entries, got %d", c.resourceCount, len(list.Hashes))
-			}
-
-			realCount, emptyCount := 0, 0
-			for _, h := range list.Hashes {
-				if h.ResourceID == "" {
-					t.Error("found entry with empty ResourceID")
-				}
-				if h.StatusHash == "" {
-					emptyCount++
-				} else {
-					realCount++
-				}
-			}
-
-			if realCount != c.wantRealHashes {
-				t.Errorf("expected %d entries with real hashes, got %d", c.wantRealHashes, realCount)
-			}
-			if emptyCount != c.wantEmptyHashes {
-				t.Errorf("expected %d entries with empty hashes, got %d", c.wantEmptyHashes, emptyCount)
-			}
-		})
-	}
-}
-
-// TestResyncConsumer5000Resources verifies the hash list content and prints the
-// payload size when the consumer manages 5000 resources (well above the batch size).
-func TestResyncConsumer5000Resources(t *testing.T) {
-	const count = 5000
+// TestResyncConsumerSendsEmptyHashList verifies that resyncConsumer sends a CloudEvent
+// with an empty ResourceStatusHashList, which signals the agent to re-publish status
+// for all its resources unconditionally.
+func TestResyncConsumerSendsEmptyHashList(t *testing.T) {
 	transport := &mockTransport{}
-	client := newTestSourceClient(transport, makeResources(count))
+	client := newTestSourceClient(transport)
 
 	if err := client.resyncConsumer(context.Background(), "consumer-1"); err != nil {
 		t.Fatalf("resyncConsumer returned unexpected error: %v", err)
 	}
 
-	list := decodeHashList(t, transport)
-
-	if len(list.Hashes) != count {
-		t.Errorf("expected %d hash entries, got %d", count, len(list.Hashes))
+	if len(transport.sentEvents) != 1 {
+		t.Fatalf("expected 1 sent event, got %d", len(transport.sentEvents))
 	}
 
-	realCount, emptyCount := 0, 0
-	for _, h := range list.Hashes {
-		if h.StatusHash == "" {
-			emptyCount++
-		} else {
-			realCount++
-		}
+	list := &cepayload.ResourceStatusHashList{}
+	if err := json.Unmarshal(transport.sentEvents[0].Data(), list); err != nil {
+		t.Fatalf("failed to decode ResourceStatusHashList: %v", err)
 	}
 
-	if realCount != statusHashBatchSize {
-		t.Errorf("expected %d real hashes, got %d", statusHashBatchSize, realCount)
+	if len(list.Hashes) != 0 {
+		t.Errorf("expected empty hash list, got %d entries", len(list.Hashes))
 	}
-	if emptyCount != count-statusHashBatchSize {
-		t.Errorf("expected %d empty hashes, got %d", count-statusHashBatchSize, emptyCount)
+}
+
+// TestAgentDecodesEmptyHashListAsFullResync simulates the agent receiving the CloudEvent
+// produced by resyncConsumer and verifies that:
+//  1. The event decodes without error using the same payload decoder the agent uses.
+//  2. The decoded hash list is empty, which is the condition in the agent's
+//     respondResyncStatusRequest that causes it to publish status for ALL its resources
+//     (agentclient.go: if len(statusHashes.Hashes) == 0 { publish all }).
+func TestAgentDecodesEmptyHashListAsFullResync(t *testing.T) {
+	transport := &mockTransport{}
+	client := newTestSourceClient(transport)
+
+	if err := client.resyncConsumer(context.Background(), "consumer-1"); err != nil {
+		t.Fatalf("resyncConsumer returned unexpected error: %v", err)
 	}
 
 	evt := transport.sentEvents[0]
 
-	hashJSONSize := len(evt.Data())
-	t.Logf("hash JSON size:          %d bytes (%.1f KB)", hashJSONSize, float64(hashJSONSize)/1024)
-
-	fullEvent, err := evt.MarshalJSON()
+	hashes, err := cepayload.DecodeStatusResyncRequest(evt)
 	if err != nil {
-		t.Fatalf("failed to marshal full CloudEvent: %v", err)
+		t.Fatalf("agent failed to decode resync event: %v", err)
 	}
-	fullEventSize := len(fullEvent)
-	t.Logf("full CloudEvent size:    %d bytes (%.1f KB)", fullEventSize, float64(fullEventSize)/1024)
-	t.Logf("envelope overhead:       %d bytes", fullEventSize-hashJSONSize)
+
+	// An empty hash list is the signal that causes the agent to publish status
+	// for every resource it manages, without performing any hash comparison.
+	if len(hashes.Hashes) != 0 {
+		t.Errorf("expected empty hash list to trigger full agent resync, got %d entries", len(hashes.Hashes))
+	}
 }
 
-// TestResyncConsumerEventStructure verifies that resyncConsumer sends a correctly
-// formed CloudEvent — right type, source, and cluster name — regardless of whether
-// the hash list contains real or empty hashes.
+// TestResyncConsumerEventStructure verifies the CloudEvent has the correct type,
+// source, and cluster name extension.
 func TestResyncConsumerEventStructure(t *testing.T) {
 	const consumer = "cluster-abc"
 
 	transport := &mockTransport{}
-	client := newTestSourceClient(transport, makeResources(statusHashBatchSize+1))
+	client := newTestSourceClient(transport)
 
 	if err := client.resyncConsumer(context.Background(), consumer); err != nil {
 		t.Fatalf("resyncConsumer returned unexpected error: %v", err)
-	}
-
-	if len(transport.sentEvents) != 1 {
-		t.Fatalf("expected 1 sent event, got %d", len(transport.sentEvents))
 	}
 
 	evt := transport.sentEvents[0]
@@ -244,12 +120,5 @@ func TestResyncConsumerEventStructure(t *testing.T) {
 	}
 	if gotCluster != consumer {
 		t.Errorf("expected clusterName %q, got %q", consumer, gotCluster)
-	}
-
-	// Confirm the last entry (beyond the batch) has an empty hash.
-	list := decodeHashList(t, transport)
-	last := list.Hashes[len(list.Hashes)-1]
-	if last.StatusHash != "" {
-		t.Errorf("expected last entry (beyond batch) to have empty StatusHash, got %q", last.StatusHash)
 	}
 }

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -113,7 +113,7 @@ func (d *sqlResourceDao) FindBySource(ctx context.Context, source string) (api.R
 func (d *sqlResourceDao) FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error) {
 	g2 := (*d.sessionFactory).New(ctx)
 	resources := api.ResourceList{}
-	if err := g2.Unscoped().Where("consumer_name = ?", consumerName).Find(&resources).Error; err != nil {
+	if err := g2.Where("consumer_name = ?", consumerName).Find(&resources).Error; err != nil {
 		return nil, err
 	}
 	return resources, nil

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -113,7 +113,7 @@ func (d *sqlResourceDao) FindBySource(ctx context.Context, source string) (api.R
 func (d *sqlResourceDao) FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error) {
 	g2 := (*d.sessionFactory).New(ctx)
 	resources := api.ResourceList{}
-	if err := g2.Where("consumer_name = ?", consumerName).Find(&resources).Error; err != nil {
+	if err := g2.Unscoped().Where("consumer_name = ?", consumerName).Find(&resources).Error; err != nil {
 		return nil, err
 	}
 	return resources, nil

--- a/plans/2026-04-29-resync-status-hash-limit.md
+++ b/plans/2026-04-29-resync-status-hash-limit.md
@@ -1,0 +1,80 @@
+# Resync Status Hash Size Limit
+
+**Date:** 2026-04-29
+
+## Problem
+
+The MQTT broker has a `max_packet_size` of 512 KB. When `SourceClientImpl.Resync()` fires (on MQTT
+reconnect, consumer reassignment, or instance failover), it delegates to the SDK's
+`CloudEventSourceClient.Resync()`, which builds a `ResourceStatusHashList` containing one entry per
+resource managed by the consumer. At elevated resource counts this payload exceeds the broker limit,
+causing the resync to fail silently.
+
+Measured: 4,029 resources → ~612 KB, which is ~100 KB over the 512 KB limit.
+
+### Root cause of the elevated count
+
+A data leak is causing resources that are no longer real to persist in the database. The resource
+count per consumer should be ~400 once the leak is fixed. At 400 resources the full hash list is
+~61 KB, well within the broker limit.
+
+## Staged Changes
+
+### 1. `pkg/dao/resource.go` — Fix soft-deleted resource leak
+
+Remove `Unscoped()` from `FindByConsumerName` so that soft-deleted resources are excluded from the
+query. Previously, deleted resources were included in the result set, inflating the hash list.
+
+```diff
+-g2.Unscoped().Where("consumer_name = ?", consumerName).Find(&resources)
++g2.Where("consumer_name = ?", consumerName).Find(&resources)
+```
+
+### 2. `pkg/client/cloudevents/source_client.go` — Hybrid hash list resync
+
+As a safety net for the period before the data leak is fully drained, replace the SDK's
+`CloudEventSourceClient.Resync()` call with a custom `resyncConsumer()` that:
+
+- Lists all resources for the consumer from the database.
+- Computes real SHA256 status hashes for the first `statusHashBatchSize` (2000) resources.
+- Includes remaining resources with an empty `StatusHash` (`""`), which causes the agent to treat
+  them as mismatched and re-publish their status unconditionally.
+- Sends the CloudEvent directly via the transport, bypassing the SDK's all-or-nothing hash build.
+
+This caps the hash computation cost and keeps the payload within 512 KB even at inflated counts.
+
+Additional changes in the same file:
+- Added `cloudevents` and `cepayload` imports.
+- Removed the duplicate `types` import alias (consolidated to `cetypes`).
+- Added `sourceID` and `transport` fields to `SourceClientImpl` so the custom resync can construct
+  and send the CloudEvent without going through the SDK's unexported `publish()` path.
+
+### 3. `pkg/client/cloudevents/source_client_test.go` — New test file
+
+Unit tests for the hybrid resync behaviour:
+
+| Test | What it verifies |
+|---|---|
+| `TestResyncConsumerHashList` | Under/at/over batch size: correct split of real vs empty hashes, all resource IDs present |
+| `TestResyncConsumerEventStructure` | Event type, source, cluster name extension, and that entries beyond the batch have empty hash |
+| `TestResyncConsumer5000Resources` | 5000-resource case; logs hash JSON size and full CloudEvent size |
+
+## Known Limitations of the Staged Approach
+
+- The message still contains every resource ID even for empty-hash entries, so payload size still
+  scales linearly with resource count. The saving vs full hashes is ~82 bytes per entry beyond the
+  batch.
+- `resyncConsumer` bypasses the SDK rate limiter in `baseClient`. Acceptable because resync is
+  one message per consumer, not a high-frequency operation.
+- The hybrid adds complexity (batch constant, DB list call, manual CloudEvent construction) that
+  becomes unnecessary once resource counts normalise to ~400.
+
+## Recommended Follow-up
+
+Once the data leak is confirmed resolved and resource counts are stable at ~400:
+
+1. Revert `resyncConsumer` back to `s.CloudEventSourceClient.Resync(ctx, consumer)`.
+2. Remove the `sourceID`, `transport` fields and associated imports from `SourceClientImpl`.
+3. Remove `statusHashBatchSize` and the hybrid test cases (or simplify to a smoke test).
+
+The `FindByConsumerName` fix in `resource.go` should be kept permanently.

--- a/plans/2026-04-29-resync-status-hash-limit.md
+++ b/plans/2026-04-29-resync-status-hash-limit.md
@@ -18,6 +18,33 @@ A data leak is causing resources that are no longer real to persist in the datab
 count per consumer should be ~400 once the leak is fixed. At 400 resources the full hash list is
 ~61 KB, well within the broker limit.
 
+## Approach
+
+Rather than a hybrid that sends partial real hashes and risks a still-large payload, send an
+**empty** `ResourceStatusHashList` (zero entries). The agent's `respondResyncStatusRequest`
+explicitly handles this case:
+
+```go
+// agentclient.go
+if len(statusHashes.Hashes) == 0 {
+    // publish all resources status
+    for _, obj := range objs {
+        if err := c.Publish(ctx, eventType, obj); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+An empty list signals the agent to re-publish status for every resource it manages
+unconditionally. The outbound message is ~20 bytes regardless of resource count.
+
+**Tradeoff:** on every resync the agent sends back status for all its resources rather than only
+changed ones. At ~400 resources (the expected steady-state count once the leak is fixed) this is
+acceptable. Resync is triggered on MQTT reconnect, consumer reassignment, and instance failover —
+not on a hot path.
+
 ## Staged Changes
 
 ### 1. `pkg/dao/resource.go` — Fix soft-deleted resource leak
@@ -30,51 +57,112 @@ query. Previously, deleted resources were included in the result set, inflating 
 +g2.Where("consumer_name = ?", consumerName).Find(&resources)
 ```
 
-### 2. `pkg/client/cloudevents/source_client.go` — Hybrid hash list resync
+### 2. `pkg/client/cloudevents/source_client.go` — Empty hash list resync
 
-As a safety net for the period before the data leak is fully drained, replace the SDK's
-`CloudEventSourceClient.Resync()` call with a custom `resyncConsumer()` that:
+Replace the SDK's `CloudEventSourceClient.Resync()` call with a custom `resyncConsumer()` that
+sends an empty `ResourceStatusHashList` directly via the transport.
 
-- Lists all resources for the consumer from the database.
-- Computes real SHA256 status hashes for the first `statusHashBatchSize` (2000) resources.
-- Includes remaining resources with an empty `StatusHash` (`""`), which causes the agent to treat
-  them as mismatched and re-publish their status unconditionally.
-- Sends the CloudEvent directly via the transport, bypassing the SDK's all-or-nothing hash build.
+Added `sourceID` and `transport` fields to `SourceClientImpl` to construct and send the CloudEvent
+without going through the SDK's unexported `publish()` path. Removed the duplicate `types` import
+alias (consolidated to `cetypes`).
 
-This caps the hash computation cost and keeps the payload within 512 KB even at inflated counts.
+```go
+type SourceClientImpl struct {
+	Codec                  cegeneric.Codec[*api.Resource]
+	CloudEventSourceClient *ceclients.CloudEventSourceClient[*api.Resource]
+	ResourceService        services.ResourceService
+	sourceID               string
+	transport              ceoptions.CloudEventTransport
+}
 
-Additional changes in the same file:
-- Added `cloudevents` and `cepayload` imports.
-- Removed the duplicate `types` import alias (consolidated to `cetypes`).
-- Added `sourceID` and `transport` fields to `SourceClientImpl` so the custom resync can construct
-  and send the CloudEvent without going through the SDK's unexported `publish()` path.
+func NewSourceClient(sourceOptions *ceoptions.CloudEventsSourceOptions, resourceService services.ResourceService) (SourceClient, error) {
+	ctx := context.Background()
+	codec := NewCodec(sourceOptions.SourceID)
+	ceSourceClient, err := ceclients.NewCloudEventSourceClient[*api.Resource](ctx, sourceOptions,
+		resourceService, ResourceStatusHashGetter, codec)
+	if err != nil {
+		return nil, err
+	}
+
+	cemetrics.RegisterSourceCloudEventsMetrics(prometheus.DefaultRegisterer)
+
+	return &SourceClientImpl{
+		Codec:                  codec,
+		CloudEventSourceClient: ceSourceClient,
+		ResourceService:        resourceService,
+		sourceID:               sourceOptions.SourceID,
+		transport:              sourceOptions.CloudEventsTransport,
+	}, nil
+}
+
+func (s *SourceClientImpl) Resync(ctx context.Context, consumers []string) error {
+	logger := klog.FromContext(ctx).WithValues("consumers", consumers)
+	ctx = klog.NewContext(ctx, logger)
+
+	logger.Info("Resyncing resource status from consumers")
+	for _, consumer := range consumers {
+		if err := s.resyncConsumer(ctx, consumer); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resyncConsumer sends a status resync request with an empty hash list to the consumer.
+// An empty list signals the agent to re-publish status for all its resources unconditionally,
+// keeping the outbound message small regardless of resource count.
+func (s *SourceClientImpl) resyncConsumer(ctx context.Context, consumer string) error {
+	eventType := cetypes.CloudEventsType{
+		CloudEventsDataType: s.Codec.EventDataType(),
+		SubResource:         cetypes.SubResourceStatus,
+		Action:              cetypes.ResyncRequestAction,
+	}
+
+	evt := cetypes.NewEventBuilder(s.sourceID, eventType).WithClusterName(consumer).NewEvent()
+	if err := evt.SetData(cloudevents.ApplicationJSON, &cepayload.ResourceStatusHashList{}); err != nil {
+		return fmt.Errorf("failed to set resync event data: %v", err)
+	}
+
+	return s.transport.Send(ctx, evt)
+}
+```
 
 ### 3. `pkg/client/cloudevents/source_client_test.go` — New test file
 
-Unit tests for the hybrid resync behaviour:
+```go
+// TestResyncConsumerSendsEmptyHashList verifies that resyncConsumer sends a CloudEvent
+// with an empty ResourceStatusHashList, which signals the agent to re-publish status
+// for all its resources unconditionally.
+func TestResyncConsumerSendsEmptyHashList(t *testing.T) { ... }
+
+// TestAgentDecodesEmptyHashListAsFullResync simulates the agent receiving the CloudEvent
+// produced by resyncConsumer and verifies that:
+//  1. The event decodes without error using the same payload decoder the agent uses.
+//  2. The decoded hash list is empty, which is the condition in the agent's
+//     respondResyncStatusRequest that causes it to publish status for ALL its resources.
+func TestAgentDecodesEmptyHashListAsFullResync(t *testing.T) { ... }
+
+// TestResyncConsumerEventStructure verifies the CloudEvent has the correct type,
+// source, and cluster name extension.
+func TestResyncConsumerEventStructure(t *testing.T) { ... }
+```
 
 | Test | What it verifies |
 |---|---|
-| `TestResyncConsumerHashList` | Under/at/over batch size: correct split of real vs empty hashes, all resource IDs present |
-| `TestResyncConsumerEventStructure` | Event type, source, cluster name extension, and that entries beyond the batch have empty hash |
-| `TestResyncConsumer5000Resources` | 5000-resource case; logs hash JSON size and full CloudEvent size |
+| `TestResyncConsumerSendsEmptyHashList` | Payload decodes to a hash list with zero entries |
+| `TestAgentDecodesEmptyHashListAsFullResync` | Agent's own decoder (`DecodeStatusResyncRequest`) parses the event and returns an empty list, confirming the full-resync branch is taken |
+| `TestResyncConsumerEventStructure` | Event type (`SubResourceStatus` + `ResyncRequestAction`), source, and cluster name extension are correct |
 
-## Known Limitations of the Staged Approach
+## Known Limitations
 
-- The message still contains every resource ID even for empty-hash entries, so payload size still
-  scales linearly with resource count. The saving vs full hashes is ~82 bytes per entry beyond the
-  batch.
-- `resyncConsumer` bypasses the SDK rate limiter in `baseClient`. Acceptable because resync is
-  one message per consumer, not a high-frequency operation.
-- The hybrid adds complexity (batch constant, DB list call, manual CloudEvent construction) that
-  becomes unnecessary once resource counts normalise to ~400.
+- `resyncConsumer` bypasses the SDK rate limiter in `baseClient`. Acceptable because resync fires
+  once per consumer per reconnect event, not in a tight loop.
+- On every resync the agent sends back status for all its resources, not just changed ones. At the
+  expected steady-state of ~400 resources this is negligible.
 
 ## Recommended Follow-up
 
-Once the data leak is confirmed resolved and resource counts are stable at ~400:
-
-1. Revert `resyncConsumer` back to `s.CloudEventSourceClient.Resync(ctx, consumer)`.
-2. Remove the `sourceID`, `transport` fields and associated imports from `SourceClientImpl`.
-3. Remove `statusHashBatchSize` and the hybrid test cases (or simplify to a smoke test).
-
-The `FindByConsumerName` fix in `resource.go` should be kept permanently.
+Once the data leak is confirmed resolved and resource counts are stable at ~400, evaluate whether
+to restore the SDK's `CloudEventSourceClient.Resync()` (full delta hashes, ~61 KB) for better
+efficiency. The `FindByConsumerName` fix in `resource.go` should be kept permanently.


### PR DESCRIPTION

  - Remove Unscoped() from FindByConsumerName so soft-deleted resources are
    excluded, fixing a data leak that inflated resource counts to ~4000
  - Replace SDK CloudEventSourceClient.Resync() with resyncConsumer() that
    sends an empty ResourceStatusHashList (~20 bytes) instead of one hash
    entry per resource (~612KB at current counts), keeping the payload well
    within the broker max_packet_size
  - Add unit tests verifying the empty hash list is sent, that the agent's
    own decoder parses it correctly and triggers a full status republish,
    and that the CloudEvent structure is well-formed