### PR TITLE
Proposal: Handle status events concurrently in StatusController

### DIFF
--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -19,6 +19,7 @@ func NewControllersServer(ctx context.Context, eventServer EventServer, eventFil
 			env().Services.StatusEvents(),
 			dao.NewInstanceDao(&env().Database.SessionFactory),
 			dao.NewEventInstanceDao(&env().Database.SessionFactory),
+			controllers.DefaultStatusControllerWorkers,
 		),
 	}
 

--- a/pkg/controllers/status_controller.go
+++ b/pkg/controllers/status_controller.go
@@ -16,6 +16,9 @@ import (
 
 const StatusEventID ControllerHandlerContextKey = "status_event"
 
+// DefaultStatusControllerWorkers is the default number of concurrent workers for the status controller
+const DefaultStatusControllerWorkers = 10
+
 type StatusHandlerFunc func(ctx context.Context, eventID, sourceID string) error
 
 type StatusController struct {
@@ -24,16 +27,22 @@ type StatusController struct {
 	instanceDao      dao.InstanceDao
 	eventInstanceDao dao.EventInstanceDao
 	eventsQueue      workqueue.TypedRateLimitingInterface[string]
+	workers          int
 }
 
 func NewStatusController(statusEvents services.StatusEventService,
 	instanceDao dao.InstanceDao,
-	eventInstanceDao dao.EventInstanceDao) *StatusController {
+	eventInstanceDao dao.EventInstanceDao,
+	workers int) *StatusController {
+	if workers == 0 {
+		workers = DefaultStatusControllerWorkers
+	}
 	return &StatusController{
 		controllers:      map[api.StatusEventType][]StatusHandlerFunc{},
 		statusEvents:     statusEvents,
 		instanceDao:      instanceDao,
 		eventInstanceDao: eventInstanceDao,
+		workers:          workers,
 		eventsQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -51,15 +60,17 @@ func (sc *StatusController) AddStatusEvent(id string) {
 
 func (sc *StatusController) Run(ctx context.Context) {
 	logger := klog.FromContext(ctx)
-	logger.Info("Starting status event controller")
+	logger.Info("Starting status event controller", "workers", sc.workers)
 	defer sc.eventsQueue.ShutDown()
 
 	// use a jitter to avoid multiple instances syncing the events at the same time
 	go wait.JitterUntilWithContext(ctx, sc.syncStatusEvents, defaultEventsSyncPeriod, 0.25, true)
 
-	// start a goroutine to handle the status event from the event queue
+	// start multiple worker goroutines to handle status events from the event queue
 	// the .Until will re-kick the runWorker one second after the runWorker completes
-	go wait.UntilWithContext(ctx, sc.runWorker, time.Second)
+	for i := 0; i < sc.workers; i++ {
+		go wait.UntilWithContext(ctx, sc.runWorker, time.Second)
+	}
 
 	// wait until we're told to stop
 	<-ctx.Done()

--- a/test/helper.go
+++ b/test/helper.go
@@ -260,6 +260,7 @@ func (helper *Helper) StartControllerManager(ctx context.Context) {
 			helper.Env().Services.StatusEvents(),
 			dao.NewInstanceDao(&helper.Env().Database.SessionFactory),
 			dao.NewEventInstanceDao(&helper.Env().Database.SessionFactory),
+			1, // use 1 worker for tests
 		),
 	}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -106,6 +106,7 @@ func TestControllerRacing(t *testing.T) {
 					h.Env().Services.StatusEvents(),
 					dao.NewInstanceDao(&h.Env().Database.SessionFactory),
 					dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+					1, // use 1 worker for tests
 				),
 			}
 
@@ -207,6 +208,7 @@ func TestControllerReconcile(t *testing.T) {
 				h.Env().Services.StatusEvents(),
 				dao.NewInstanceDao(&h.Env().Database.SessionFactory),
 				dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+				1, // use 1 worker for tests
 			),
 		}
 
@@ -366,6 +368,7 @@ func TestControllerSync(t *testing.T) {
 				h.Env().Services.StatusEvents(),
 				dao.NewInstanceDao(&h.Env().Database.SessionFactory),
 				dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+				1, // use 1 worker for tests
 			),
 		}
 
@@ -511,6 +514,7 @@ func TestStatusControllerSync(t *testing.T) {
 				h.Env().Services.StatusEvents(),
 				dao.NewInstanceDao(&h.Env().Database.SessionFactory),
 				dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+				1, // use 1 worker for tests
 			),
 		}
 
@@ -590,6 +594,7 @@ func TestMultipleControllers(t *testing.T) {
 		h.Env().Services.StatusEvents(),
 		dao.NewInstanceDao(&h.Env().Database.SessionFactory),
 		dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+		1, // use 1 worker for tests
 	)
 	statusCtrl.Add(map[api.StatusEventType][]controllers.StatusHandlerFunc{
 		api.StatusUpdateEventType: {func(ctx context.Context, eventID, sourceID string) error { return nil }},


### PR DESCRIPTION
# Summary                                                                                                                                                                                                          
This change introduces concurrent processing capabilities to the StatusController, enabling it to handle multiple status events in parallel instead of processing them sequentially. This improvement addresses  
  potential performance bottlenecks when processing high volumes of status updates from managed clusters.
                                                
## Changes                                       
  - Default concurrency: Set DefaultStatusControllerWorkers to 10.
  - Concurrent event processing: Modified the Run() method to spawn multiple worker goroutines using wait.UntilWithContext()                                                                                       
  - Test compatibility: All test instantiations use 1 worker to maintain deterministic behavior and avoid race conditions in test scenarios
                                                                                                                                                                                                                   
 ## Technical Details                                                                                                                                                                                                
                                                                                                                                               
  Key implementation notes:                                                                                                                                                                                        
  - Workers process events from the shared eventsQueue workqueue with rate limiting                                                                                                                                
  - The existing synchronization mechanisms (workqueue, rate limiting) ensure thread-safe event processing                                                                                                         
  - Graceful shutdown handling remains unchanged - all workers terminate when the context is canceled     
                                                                                                                                                                                                                   
  ## Performance Impact and testing                                                                                                                                                                                   
 - Tested using a load test creating 10,15,20 concurrent clusters against a dev-env and measuring the time from `Accepted` to `Succeeded` - performance gain is anywhere between 1m-3m (~10-20% decrease):

<img width="1650" height="1050" alt="maestro_max_comparison" src="https://github.com/user-attachments/assets/e41bba47-42c1-44d7-b905-2e21a19cb1e1" />
