### PR TITLE
[ARO-26755] Add metrics for the postgres notify buffered channel 

### DIFF
--- a/pkg/db/db_session/default.go
+++ b/pkg/db/db_session/default.go
@@ -149,6 +149,13 @@ func waitForNotification(ctx context.Context, l *pq.Listener, dbConfig *config.D
 			if n != nil {
 				logger.V(4).Info("Received event from channel", "channel", n.Channel, "extra", n.Extra)
 				callback(n.Extra)
+				// Record notify channel depth metric
+				depth := len(l.Notify) + 1 // +1 accounts for the just-dequeued notification
+				notifyChannelDepthGauge.WithLabelValues(channel).Set(float64(depth))
+				if depth == notifyChannelCapacity {
+					logger.Info("Postgres NOTIFY channel buffer at capacity", "channel", channel, "capacity", notifyChannelCapacity)
+					notifyChannelFullCounter.WithLabelValues(channel).Inc()
+				}
 			} else {
 				// nil notification means the connection was closed
 				logger.Info("recreate the listener for channel due to the connection loss", "channel", channel)

--- a/pkg/db/db_session/metrics.go
+++ b/pkg/db/db_session/metrics.go
@@ -1,0 +1,36 @@
+package db_session
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// Notify channel capacity in github.com/lib/pq
+	notifyChannelCapacity = 32
+)
+
+// Metric for PostgreSQL NOTIFY channel buffer depth
+var (
+	notifyChannelDepthGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: "db",
+			Name:      "notify_channel_depth",
+			Help:      "Current depth of the PostgreSQL NOTIFY channel buffer (capacity: 32)",
+		},
+		[]string{"channel"},
+	)
+
+	notifyChannelFullCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "db",
+			Name:      "notify_channel_full_total",
+			Help:      "Total number of times the NOTIFY channel buffer reached capacity (32/32)",
+		},
+		[]string{"channel"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(notifyChannelDepthGauge)
+	prometheus.MustRegister(notifyChannelFullCounter)
+}

--- a/pkg/db/db_session/metrics_test.go
+++ b/pkg/db/db_session/metrics_test.go
@@ -1,0 +1,140 @@
+package db_session
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestNotifyChannelMetrics(t *testing.T) {
+	// Reset metrics before test
+	notifyChannelDepthGauge.Reset()
+	notifyChannelFullCounter.Reset()
+
+	testChannel := "test_channel"
+
+	t.Run("DepthGaugeRecordsValue", func(t *testing.T) {
+		// Set depth to 10
+		notifyChannelDepthGauge.WithLabelValues(testChannel).Set(10)
+
+		// Verify the gauge value
+		value := getGaugeValue(t, "db_notify_channel_depth", testChannel)
+		if value != 10 {
+			t.Errorf("Expected depth gauge value 10, got %f", value)
+		}
+	})
+
+	t.Run("FullCounterIncrementsAtCapacity", func(t *testing.T) {
+		// Reset counter
+		notifyChannelFullCounter.Reset()
+
+		// Simulate buffer reaching capacity
+		notifyChannelFullCounter.WithLabelValues(testChannel).Inc()
+
+		// Verify counter incremented
+		value := getCounterValue(t, "db_notify_channel_full_total", testChannel)
+		if value != 1 {
+			t.Errorf("Expected counter value 1, got %f", value)
+		}
+
+		// Increment again
+		notifyChannelFullCounter.WithLabelValues(testChannel).Inc()
+
+		// Verify counter is now 2
+		value = getCounterValue(t, "db_notify_channel_full_total", testChannel)
+		if value != 2 {
+			t.Errorf("Expected counter value 2, got %f", value)
+		}
+	})
+
+	t.Run("CapacityConstant", func(t *testing.T) {
+		// Verify the capacity constant is set correctly
+		if notifyChannelCapacity != 32 {
+			t.Errorf("Expected capacity 32, got %d", notifyChannelCapacity)
+		}
+	})
+
+	t.Run("MultipleChannels", func(t *testing.T) {
+		// Reset metrics
+		notifyChannelDepthGauge.Reset()
+		notifyChannelFullCounter.Reset()
+
+		// Set values for different channels
+		notifyChannelDepthGauge.WithLabelValues("events").Set(5)
+		notifyChannelDepthGauge.WithLabelValues("status_events").Set(28)
+
+		notifyChannelFullCounter.WithLabelValues("status_events").Inc()
+
+		// Verify each channel has independent values
+		eventsDepth := getGaugeValue(t, "db_notify_channel_depth", "events")
+		statusDepth := getGaugeValue(t, "db_notify_channel_depth", "status_events")
+
+		if eventsDepth != 5 {
+			t.Errorf("Expected events depth 5, got %f", eventsDepth)
+		}
+
+		if statusDepth != 28 {
+			t.Errorf("Expected status_events depth 28, got %f", statusDepth)
+		}
+
+		// Verify counter only incremented for status_events
+		eventsCounter := getCounterValue(t, "db_notify_channel_full_total", "events")
+		statusCounter := getCounterValue(t, "db_notify_channel_full_total", "status_events")
+
+		if eventsCounter != 0 {
+			t.Errorf("Expected events counter 0, got %f", eventsCounter)
+		}
+
+		if statusCounter != 1 {
+			t.Errorf("Expected status_events counter 1, got %f", statusCounter)
+		}
+	})
+}
+
+func getGaugeValue(t *testing.T, metricName, channel string) float64 {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if matchesChannel(m.GetLabel(), channel) {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+func getCounterValue(t *testing.T, metricName, channel string) float64 {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if matchesChannel(m.GetLabel(), channel) {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+func matchesChannel(labels []*dto.LabelPair, channel string) bool {
+	for _, label := range labels {
+		if label.GetName() == "channel" && label.GetValue() == channel {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/db_notify_metrics_test.go
+++ b/test/integration/db_notify_metrics_test.go
@@ -1,0 +1,159 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/openshift-online/maestro/test"
+)
+
+func TestNotifyChannelMetrics(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a channel to collect notification IDs
+	received := make(chan string, 100)
+
+	// Start listener with callback that collects notifications
+	listener := h.Env().Database.SessionFactory.NewListener(ctx, "metrics_test_channel", func(id string) {
+		received <- id
+		// Introduce a small delay to allow buffer to fill up
+		time.Sleep(10 * time.Millisecond)
+	})
+	defer listener.Close()
+
+	// Wait for listener to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	g2 := h.Env().Database.SessionFactory.New(ctx)
+
+	// Test 1: Send notifications that should NOT fill the buffer
+	t.Run("LowDepthDoesNotTriggerAlert", func(t *testing.T) {
+		// Get initial counter value
+		initialFull := getCounterValue(t, "db_notify_channel_full_total", map[string]string{"channel": "metrics_test_channel"})
+
+		// Send a few notifications (well below capacity of 32)
+		for i := 0; i < 5; i++ {
+			if err := g2.Exec("SELECT pg_notify('metrics_test_channel', $1)", i).Error; err != nil {
+				t.Fatalf("Failed to send notification: %v", err)
+			}
+		}
+
+		// Wait for processing
+		time.Sleep(500 * time.Millisecond)
+
+		// Verify depth gauge is recorded (should be low)
+		depth := getGaugeValue(t, "db_notify_channel_depth", map[string]string{"channel": "metrics_test_channel"})
+		if depth > 5 {
+			t.Errorf("Expected depth <= 5, got %f", depth)
+		}
+
+		// Verify full counter did NOT increment
+		finalFull := getCounterValue(t, "db_notify_channel_full_total", map[string]string{"channel": "metrics_test_channel"})
+		if finalFull != initialFull {
+			t.Errorf("Expected full counter to remain at %f, but got %f", initialFull, finalFull)
+		}
+	})
+
+	// Test 2: Send many notifications rapidly to fill the buffer
+	t.Run("HighDepthTriggersAlert", func(t *testing.T) {
+		// Get initial counter value
+		initialFull := getCounterValue(t, "db_notify_channel_full_total", map[string]string{"channel": "metrics_test_channel"})
+
+		// Send 32+ notifications rapidly to fill the buffer (capacity is 32)
+		// The slow callback should cause buffer to fill up
+		for i := 0; i < 35; i++ {
+			if err := g2.Exec("SELECT pg_notify('metrics_test_channel', $1)", i).Error; err != nil {
+				t.Fatalf("Failed to send notification: %v", err)
+			}
+		}
+
+		// Give time for at least one notification to be processed (which records metrics)
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify depth gauge shows high value
+		depth := getGaugeValue(t, "db_notify_channel_depth", map[string]string{"channel": "metrics_test_channel"})
+		t.Logf("Buffer depth: %f", depth)
+
+		// Verify full counter incremented (at least once)
+		Eventually(func() bool {
+			finalFull := getCounterValue(t, "db_notify_channel_full_total", map[string]string{"channel": "metrics_test_channel"})
+			return finalFull > initialFull
+		}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "Expected full counter to increment when buffer reaches capacity")
+	})
+
+	// Clean up: drain remaining notifications
+drainLoop:
+	for {
+		select {
+		case <-received:
+		case <-time.After(100 * time.Millisecond):
+			break drainLoop
+		}
+	}
+}
+
+// getGaugeValue retrieves the current value of a gauge metric
+func getGaugeValue(t *testing.T, metricName string, labels map[string]string) float64 {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if labelsMatch(m.GetLabel(), labels) {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	// Return 0 if metric not found (hasn't been recorded yet)
+	return 0
+}
+
+// getCounterValue retrieves the current value of a counter metric
+func getCounterValue(t *testing.T, metricName string, labels map[string]string) float64 {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if labelsMatch(m.GetLabel(), labels) {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	// Return 0 if metric not found (hasn't been recorded yet)
+	return 0
+}
+
+// labelsMatch checks if metric labels match the expected labels
+func labelsMatch(metricLabels []*dto.LabelPair, expectedLabels map[string]string) bool {
+	if len(metricLabels) != len(expectedLabels) {
+		return false
+	}
+
+	for _, label := range metricLabels {
+		expectedValue, exists := expectedLabels[label.GetName()]
+		if !exists || expectedValue != label.GetValue() {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
### Summary
Adds Prometheus metrics to monitor the PostgreSQL NOTIFY channel buffer depth and alert when it approaches capacity, helping detect potential notification drops before they occur.

### Problem
The `github.com/lib/pq` library uses a buffered channel with a [fixed capacity of 32 slots](https://github.com/lib/pq/blob/master/notify.go#L498) for NOTIFY messages (`pq.Listener.Notify`). When the buffer is full and new notifications arrive, messages are held back and the postgress connection is held. This can happen when:
- Database sends notifications faster than the application processes them
- Notification callback processing is slow or blocks
- Temporary processing delays create backpressure

Without visibility into the buffer depth, dropped notifications go undetected until they manifest as missing events downstream.

### Solution
Introduces two new Prometheus metrics to monitor NOTIFY channel health:

1. **`db_notify_channel_depth`** (Gauge)
   - Current number of pending notifications in the buffer
   - Labeled by channel name
   - Recorded on every notification received and during periodic health checks (10s interval)

2. **`db_notify_channel_full_total`** (Counter)
   - Increments when buffer depth exceeds capacity (32/32)
   - Labeled by channel name
   - Indicates the buffer is at saturation
