### PR TITLE
fix(controllers): detect and re-publish resources with no status feedback

### DIFF
--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/pkg/api"
@@ -38,6 +40,16 @@ func NewControllersServer(ctx context.Context, eventServer EventServer, eventFil
 				api.DeleteEventType: {eventServer.OnDelete},
 			},
 		})
+
+		threshold := env().Config.EventServer.UndeliveredResourceThreshold
+		if threshold > 0 {
+			s.UndeliveredDetector = controllers.NewUndeliveredDetector(
+				env().Services.Resources(),
+				env().Services.Events(),
+				db.NewAdvisoryLockFactory(env().Database.SessionFactory),
+				threshold,
+			)
+		}
 	}
 
 	s.StatusController.Add(map[api.StatusEventType][]controllers.StatusHandlerFunc{
@@ -51,6 +63,7 @@ func NewControllersServer(ctx context.Context, eventServer EventServer, eventFil
 type ControllersServer struct {
 	KindControllerManager *controllers.KindControllerManager
 	StatusController      *controllers.StatusController
+	UndeliveredDetector   *controllers.UndeliveredDetector
 
 	DB db.SessionFactory
 }
@@ -65,6 +78,11 @@ func (s ControllersServer) Start(ctx context.Context) {
 
 		logger.Info("Kind controller listening for events")
 		go env().Database.SessionFactory.NewListener(ctx, "events", s.KindControllerManager.AddEvent)
+	}
+
+	if s.UndeliveredDetector != nil {
+		logger.Info("Starting undelivered resource detector")
+		go wait.JitterUntilWithContext(ctx, s.UndeliveredDetector.Run, 2*time.Minute, 0.25, true)
 	}
 
 	logger.Info("Status controller handling events")

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -81,6 +81,7 @@ maestro server [flags]
 | `--message-broker-type` | `mqtt` | Broker type: `mqtt`, `grpc`, or `pubsub` |
 | `--message-broker-config-file` | `secrets/mqtt.config` | Broker config file path |
 | `--subscription-type` | `shared` | Subscription type: `shared` or `broadcast` |
+| `--undelivered-resource-threshold` | `600` | Seconds a resource can have no status (NULL) before being re-published to the message broker. Set to `0` to disable |
 
 ### HTTP/REST API Configuration
 

--- a/pkg/config/event_server.go
+++ b/pkg/config/event_server.go
@@ -13,8 +13,9 @@ const (
 
 // EventServerConfig contains the configuration for the message queue event server.
 type EventServerConfig struct {
-	SubscriptionType     string                `json:"subscription_type"`
-	ConsistentHashConfig *ConsistentHashConfig `json:"consistent_hash_config"`
+	SubscriptionType             string                `json:"subscription_type"`
+	ConsistentHashConfig         *ConsistentHashConfig `json:"consistent_hash_config"`
+	UndeliveredResourceThreshold int                   `json:"undelivered_resource_threshold"`
 }
 
 // ConsistentHashConfig contains the configuration for the consistent hashing algorithm.
@@ -27,8 +28,9 @@ type ConsistentHashConfig struct {
 // NewEventServerConfig creates a new EventServerConfig with default settings.
 func NewEventServerConfig() *EventServerConfig {
 	return &EventServerConfig{
-		SubscriptionType:     "shared",
-		ConsistentHashConfig: NewConsistentHashConfig(),
+		SubscriptionType:             "shared",
+		ConsistentHashConfig:         NewConsistentHashConfig(),
+		UndeliveredResourceThreshold: 600,
 	}
 }
 
@@ -52,6 +54,7 @@ func NewConsistentHashConfig() *ConsistentHashConfig {
 //     If subscription type is "broadcast", ConsistentHashConfig settings can be configured for the hashing algorithm.
 func (c *EventServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.SubscriptionType, "subscription-type", c.SubscriptionType, "Sets the subscription type for resource status updates from message broker, Options: \"shared\" (only one instance receives resource status message, MQTT feature ensures exclusivity) or \"broadcast\" (all instances receive messages, hashed to determine processing instance)")
+	fs.IntVar(&c.UndeliveredResourceThreshold, "undelivered-resource-threshold", c.UndeliveredResourceThreshold, "Seconds a resource can have no status (NULL) before being re-published to the message broker. Set to 0 to disable. Default: 600 (10 minutes)")
 	c.ConsistentHashConfig.AddFlags(fs)
 }
 

--- a/pkg/config/event_server_test.go
+++ b/pkg/config/event_server_test.go
@@ -23,6 +23,7 @@ func TestEventServerConfig(t *testing.T) {
 					ReplicationFactor: 20,
 					Load:              1.25,
 				},
+				UndeliveredResourceThreshold: 600,
 			},
 		},
 		{
@@ -37,6 +38,7 @@ func TestEventServerConfig(t *testing.T) {
 					ReplicationFactor: 20,
 					Load:              1.25,
 				},
+				UndeliveredResourceThreshold: 600,
 			},
 		},
 		{
@@ -54,6 +56,7 @@ func TestEventServerConfig(t *testing.T) {
 					ReplicationFactor: 30,
 					Load:              1.5,
 				},
+				UndeliveredResourceThreshold: 600,
 			},
 		},
 	}

--- a/pkg/controllers/undelivered_detector.go
+++ b/pkg/controllers/undelivered_detector.go
@@ -1,0 +1,97 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/db"
+	"github.com/openshift-online/maestro/pkg/services"
+)
+
+var undeliveredResourcesRepublishedTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Subsystem: specControllerMetricsSubsystem,
+		Name:      "undelivered_resources_republished_total",
+		Help:      "Total number of resources re-published because they had no status feedback within the threshold",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(undeliveredResourcesRepublishedTotal)
+}
+
+type UndeliveredDetector struct {
+	resourceService services.ResourceService
+	events          services.EventService
+	lockFactory     db.LockFactory
+	threshold       time.Duration
+}
+
+func NewUndeliveredDetector(
+	resourceService services.ResourceService,
+	events services.EventService,
+	lockFactory db.LockFactory,
+	thresholdSeconds int,
+) *UndeliveredDetector {
+	return &UndeliveredDetector{
+		resourceService: resourceService,
+		events:          events,
+		lockFactory:     lockFactory,
+		threshold:       time.Duration(thresholdSeconds) * time.Second,
+	}
+}
+
+func (d *UndeliveredDetector) Run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	lockOwnerID, acquired, err := d.lockFactory.NewNonBlockingLock(ctx, "maestro-undelivered-check", db.Instances)
+	defer d.lockFactory.Unlock(ctx, lockOwnerID)
+	if err != nil {
+		logger.Error(err, "Error obtaining the undelivered resource check lock")
+		return
+	}
+	if !acquired {
+		logger.V(4).Info("Another instance is checking undelivered resources, skip")
+		return
+	}
+
+	resources, svcErr := d.resourceService.FindUndelivered(ctx, d.threshold)
+	if svcErr != nil {
+		logger.Error(svcErr, "Failed to find undelivered resources")
+		return
+	}
+
+	if len(resources) == 0 {
+		return
+	}
+
+	logger.Info("Found resources with no status feedback, re-publishing", "count", len(resources))
+
+	for _, resource := range resources {
+		age := time.Since(resource.CreatedAt)
+		eventType := api.CreateEventType
+		if resource.Version > 1 {
+			eventType = api.UpdateEventType
+		}
+
+		if _, err := d.events.Create(ctx, &api.Event{
+			Source:    "Resources",
+			SourceID:  resource.ID,
+			EventType: eventType,
+		}); err != nil {
+			logger.Error(err, "Failed to create re-publish event", "resourceID", resource.ID)
+			continue
+		}
+
+		undeliveredResourcesRepublishedTotal.Inc()
+		logger.Info("Re-published undelivered resource",
+			"resourceID", resource.ID,
+			"consumerName", resource.ConsumerName,
+			"source", resource.Source,
+			"age", age.String())
+	}
+}

--- a/pkg/controllers/undelivered_detector_test.go
+++ b/pkg/controllers/undelivered_detector_test.go
@@ -1,0 +1,91 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/dao/mocks"
+	dbmocks "github.com/openshift-online/maestro/pkg/db/mocks"
+	"github.com/openshift-online/maestro/pkg/services"
+)
+
+func TestUndeliveredDetector(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx := context.Background()
+	resourcesDao := mocks.NewResourceDao()
+	eventsDao := mocks.NewEventDao()
+	resourceService := services.NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourcesDao, services.NewEventService(eventsDao), nil)
+	eventService := services.NewEventService(eventsDao)
+
+	threshold := 5 * time.Minute
+	detector := NewUndeliveredDetector(resourceService, eventService, dbmocks.NewMockAdvisoryLockFactory(), int(threshold.Seconds()))
+
+	// Resource created 10 minutes ago with no status — should be re-published
+	staleResource := &api.Resource{
+		Meta:         api.Meta{ID: "stale-1", CreatedAt: time.Now().Add(-10 * time.Minute)},
+		Version:      1,
+		ConsumerName: "cluster1",
+		Source:       "test",
+	}
+	_, err := resourcesDao.Create(ctx, staleResource)
+	Expect(err).To(BeNil())
+
+	// Resource created 1 minute ago with no status — too young, should NOT be re-published
+	freshResource := &api.Resource{
+		Meta:         api.Meta{ID: "fresh-1", CreatedAt: time.Now().Add(-1 * time.Minute)},
+		Version:      1,
+		ConsumerName: "cluster1",
+		Source:       "test",
+	}
+	_, err = resourcesDao.Create(ctx, freshResource)
+	Expect(err).To(BeNil())
+
+	// Resource created 10 minutes ago WITH status — already delivered, should NOT be re-published
+	deliveredResource := &api.Resource{
+		Meta:         api.Meta{ID: "delivered-1", CreatedAt: time.Now().Add(-10 * time.Minute)},
+		Version:      1,
+		ConsumerName: "cluster1",
+		Source:       "test",
+		Status:       map[string]interface{}{"some": "status"},
+	}
+	_, err = resourcesDao.Create(ctx, deliveredResource)
+	Expect(err).To(BeNil())
+
+	// Resource created 10 minutes ago, version > 1, no status — should get UpdateEventType
+	updatedResource := &api.Resource{
+		Meta:         api.Meta{ID: "updated-1", CreatedAt: time.Now().Add(-10 * time.Minute)},
+		Version:      3,
+		ConsumerName: "cluster2",
+		Source:       "test",
+	}
+	_, err = resourcesDao.Create(ctx, updatedResource)
+	Expect(err).To(BeNil())
+
+	detector.Run(ctx)
+
+	events, err := eventsDao.All(ctx)
+	Expect(err).To(BeNil())
+
+	// Should have exactly 2 events: one for stale-1 (Create) and one for updated-1 (Update)
+	Expect(events).To(HaveLen(2))
+
+	eventsBySourceID := map[string]*api.Event{}
+	for _, e := range events {
+		eventsBySourceID[e.SourceID] = e
+	}
+
+	Expect(eventsBySourceID).To(HaveKey("stale-1"))
+	Expect(eventsBySourceID["stale-1"].EventType).To(Equal(api.CreateEventType))
+	Expect(eventsBySourceID["stale-1"].Source).To(Equal("Resources"))
+
+	Expect(eventsBySourceID).To(HaveKey("updated-1"))
+	Expect(eventsBySourceID["updated-1"].EventType).To(Equal(api.UpdateEventType))
+
+	Expect(eventsBySourceID).NotTo(HaveKey("fresh-1"))
+	Expect(eventsBySourceID).NotTo(HaveKey("delivered-1"))
+}

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -70,6 +71,21 @@ func (d *resourceDaoMock) FindBySource(ctx context.Context, source string) (api.
 	var resources api.ResourceList
 	for _, resource := range d.resources {
 		if resource.Source == source {
+			resources = append(resources, resource)
+		}
+	}
+	return resources, nil
+}
+
+// FindUndelivered returns resources with empty status older than threshold.
+// Unlike the production implementation, this mock does not validate consumer
+// existence/deletion or check for in-flight events - those are tested via
+// integration tests.
+func (d *resourceDaoMock) FindUndelivered(ctx context.Context, threshold time.Duration) (api.ResourceList, error) {
+	var resources api.ResourceList
+	cutoff := time.Now().Add(-threshold)
+	for _, resource := range d.resources {
+		if len(resource.Status) == 0 && resource.DeletedAt.Time.IsZero() && resource.CreatedAt.Before(cutoff) {
 			resources = append(resources, resource)
 		}
 	}

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"time"
 
 	"gorm.io/gorm/clause"
 
@@ -18,6 +19,7 @@ type ResourceDao interface {
 	FindByIDs(ctx context.Context, ids []string) (api.ResourceList, error)
 	FindBySource(ctx context.Context, source string) (api.ResourceList, error)
 	FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error)
+	FindUndelivered(ctx context.Context, threshold time.Duration) (api.ResourceList, error)
 	All(ctx context.Context) (api.ResourceList, error)
 	FirstByConsumerName(ctx context.Context, name string, unscoped bool) (api.Resource, error)
 }
@@ -123,6 +125,22 @@ func (d *sqlResourceDao) All(ctx context.Context) (api.ResourceList, error) {
 	g2 := (*d.sessionFactory).New(ctx)
 	resources := api.ResourceList{}
 	if err := g2.Unscoped().Find(&resources).Error; err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
+// FindUndelivered returns resources that have no status feedback and were created before
+// the cutoff time, but only if the resource's consumer still exists (not deleted).
+func (d *sqlResourceDao) FindUndelivered(ctx context.Context, threshold time.Duration) (api.ResourceList, error) {
+	g2 := (*d.sessionFactory).New(ctx)
+	resources := api.ResourceList{}
+	cutoff := time.Now().Add(-threshold)
+	if err := g2.Unscoped().
+		Joins("JOIN consumers ON consumers.name = resources.consumer_name AND consumers.deleted_at IS NULL").
+		Where("resources.deleted_at IS NULL AND resources.status IS NULL AND resources.created_at < ?", cutoff).
+		Where("NOT EXISTS (SELECT 1 FROM events WHERE events.source_id = resources.id AND events.source = 'Resources' AND events.reconciled_date IS NULL)").
+		Find(&resources).Error; err != nil {
 		return nil, err
 	}
 	return resources, nil

--- a/pkg/services/resource.go
+++ b/pkg/services/resource.go
@@ -33,6 +33,7 @@ type ResourceService interface {
 
 	FindByIDs(ctx context.Context, ids []string) (api.ResourceList, *errors.ServiceError)
 	FindBySource(ctx context.Context, source string) (api.ResourceList, *errors.ServiceError)
+	FindUndelivered(ctx context.Context, threshold time.Duration) (api.ResourceList, *errors.ServiceError)
 	List(ctx context.Context, listOpts cetypes.ListOptions) ([]*api.Resource, error)
 	ListWithArgs(ctx context.Context, username string, args *ListArguments, resources *[]api.Resource) (*api.PagingMeta, *errors.ServiceError)
 }
@@ -307,6 +308,14 @@ func (s *sqlResourceService) FindBySource(ctx context.Context, source string) (a
 	resources, err := s.resourceDao.FindBySource(ctx, source)
 	if err != nil {
 		return nil, handleGetError("Resource", "source", source, err)
+	}
+	return resources, nil
+}
+
+func (s *sqlResourceService) FindUndelivered(ctx context.Context, threshold time.Duration) (api.ResourceList, *errors.ServiceError) {
+	resources, err := s.resourceDao.FindUndelivered(ctx, threshold)
+	if err != nil {
+		return nil, errors.GeneralError("unable to find undelivered resources: %s", err)
 	}
 	return resources, nil
 }


### PR DESCRIPTION
## Description

Resources can get persisted to the database but never delivered to the agent if the transport stream tears down between the DB commit and broker enqueue. Once the event is marked reconciled, there is no mechanism to detect the gap.

Add an undelivered resource detector that periodically scans for resources with empty status older than a configurable threshold (default 10 minutes). For each, it creates a new event to trigger re-publishing through the existing pipeline. Only resources with active (non-deleted) consumers are re-published.

New flag: `--undelivered-resource-threshold` (seconds, default 600, set to 0 to disable).

Fixes https://redhat.atlassian.net/browse/AROSLSRE-833

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

1. Start server with a short threshold (60s) in gRPC mode
```maestro server --message-broker-type=grpc --undelivered-resource-threshold=60```

2. In another terminal, create a consumer and a stuck resource
```
  PGPASSWORD=foobar-bizz-buzz psql -h localhost -U maestro maestro -c "
  INSERT INTO consumers (id, name, created_at, updated_at)
  VALUES ('test-consumer-id', 'test-cluster', NOW(), NOW());

  INSERT INTO resources (id, name, version, source, consumer_name, type, payload, status, created_at, updated_at)
  VALUES ('stuck-resource', 'stuck-resource', 1, 'maestro', 'test-cluster', '', '{}', NULL, NOW() - INTERVAL '2 minutes', NOW());
  "
```

3. Watch server logs. Within ~2 minutes you should see:
```
    "Found resources with no status feedback, re-publishing" count=1
    "Re-published undelivered resource" resourceID="stuck-resource"
```

4. Verify event was created
```
  PGPASSWORD=foobar-bizz-buzz psql -h localhost -U maestro maestro \
    -c "SELECT source_id, event_type FROM events;"
  # Expected: stuck-resource | Create
```

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
