### PR TITLE
HYPERFLEET-1120 - feat(charts): expose podAnnotations and priorityClassName on agent/postgresql/mosquitto templates

### DIFF
--- a/charts/maestro-agent/Chart.yaml
+++ b/charts/maestro-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro-agent
 description: Helm chart for Maestro Agent - Receives and applies Kubernetes resources to target clusters
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 keywords:
   - maestro

--- a/charts/maestro-agent/templates/deployment.yaml
+++ b/charts/maestro-agent/templates/deployment.yaml
@@ -13,7 +13,14 @@ spec:
     metadata:
       labels:
         {{- include "maestro-agent.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "maestro-agent.serviceAccountName" . }}
       containers:
       - name: maestro-agent

--- a/charts/maestro-agent/values.yaml
+++ b/charts/maestro-agent/values.yaml
@@ -17,6 +17,12 @@ cloudeventsClientId: cluster1-work-agent
 # default client certificate refresh/reload duration for message broker
 clientCertRefreshDuration: 5m
 
+# Pod annotations (e.g., cluster-autoscaler.kubernetes.io/safe-to-evict: "false")
+podAnnotations: {}
+
+# Priority class name for the agent pod
+priorityClassName: ""
+
 # Service Account configuration
 serviceAccount:
   name: maestro-agent-sa

--- a/charts/maestro-server/Chart.yaml
+++ b/charts/maestro-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro-server
 description: Helm chart for Maestro Server - CloudEvents-based Kubernetes resource delivery system
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 keywords:
   - maestro

--- a/charts/maestro-server/templates/deployment.yaml
+++ b/charts/maestro-server/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "maestro-server.serviceAccountName" . }}
       volumes:
       - name: logging-config

--- a/charts/maestro-server/templates/mosquitto.yaml
+++ b/charts/maestro-server/templates/mosquitto.yaml
@@ -35,7 +35,14 @@ spec:
     metadata:
       labels:
         name: {{ .Values.mosquitto.service.name }}
+      {{- with .Values.mosquitto.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.mosquitto.priorityClassName }}
+      priorityClassName: {{ .Values.mosquitto.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "maestro-server.serviceAccountName" . }}
       containers:
       - image: {{ .Values.mosquitto.image }}

--- a/charts/maestro-server/templates/postgresql.yaml
+++ b/charts/maestro-server/templates/postgresql.yaml
@@ -52,7 +52,14 @@ spec:
     metadata:
       labels:
         name: {{ .Values.postgresql.service.name }}
+      {{- with .Values.postgresql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.postgresql.priorityClassName }}
+      priorityClassName: {{ .Values.postgresql.priorityClassName }}
+      {{- end }}
       containers:
         - name: postgresql
           image: {{ .Values.postgresql.image }}

--- a/charts/maestro-server/values.yaml
+++ b/charts/maestro-server/values.yaml
@@ -109,6 +109,7 @@ pubsubEmulator:
 # Server configuration
 server:
   annotations: {}
+  priorityClassName: ""
   https:
     enabled: false
   hostname: ""
@@ -178,6 +179,8 @@ postgresql:
     enabled: true
     size: 512Mi
   secretName: maestro-db
+  podAnnotations: {}
+  priorityClassName: ""
 
 # MQTT broker deployment (optional, for development)
 mosquitto:
@@ -195,3 +198,5 @@ mosquitto:
     clientCertFile: /secrets/mqtt-certs/client.crt
     # Path to client key file (inside the maestro-server-certs secret)
     clientKeyFile: /secrets/mqtt-certs/client.key
+  podAnnotations: {}
+  priorityClassName: ""


### PR DESCRIPTION
## Summary

Expose `podAnnotations` and `priorityClassName` on agent, postgresql, and mosquitto deployment templates. Adds `priorityClassName` to the server deployment (already has `server.annotations`). Bumps both charts to `0.1.1`.

Empty defaults emit no new YAML — backward compatible.

## Verification

- `helm lint` passes on both charts
- `helm template` with defaults produces identical output to pre-change (minus version label)
- All 4 templates render correctly with populated values

## Test plan

- [ ] `helm template test charts/maestro-agent` — no annotations/priorityClassName
- [ ] `helm template test charts/maestro-agent --set podAnnotations."safe-to-evict"=false --set priorityClassName=hyperfleet-critical` — both rendered
- [ ] Same for server, postgresql, mosquitto
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions to 0.1.1 for maestro-agent and maestro-server

* **New Features**
  * Added configurable pod annotations and priority class names across all deployments (maestro-agent, server, PostgreSQL, and Mosquitto), enabling enhanced Kubernetes pod scheduling and metadata customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->