### PR TITLE
fix(healthcheck): add process-only /livez liveness endpoint

### DIFF
--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -46,6 +46,7 @@ func NewHealthCheckServer(ctx context.Context) *HealthCheckServer {
 	}
 
 	router.HandleFunc("/healthcheck", server.healthCheckHandler).Methods(http.MethodGet)
+	router.HandleFunc("/livez", server.livenessHandler).Methods(http.MethodGet)
 
 	return server
 }
@@ -201,5 +202,19 @@ func (s *HealthCheckServer) healthCheckHandler(w http.ResponseWriter, r *http.Re
 	_, err = w.Write([]byte(`{"status": "not ready"}`))
 	if err != nil {
 		logger.Error(err, "Error writing healthcheck response")
+	}
+}
+
+// livenessHandler always returns 200 OK as long as the process can serve HTTP.
+// It deliberately does NOT touch Postgres (unlike healthCheckHandler), so that a
+// transient database slowdown removes the pod from Service endpoints via the
+// readiness probe (/healthcheck) instead of triggering a kubelet restart of the
+// process. Pointing the liveness probe at this endpoint prevents a recoverable
+// DB blip from escalating into a restart/reconnect storm.
+func (s *HealthCheckServer) livenessHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(`{"status": "ok"}`)); err != nil {
+		logger := klog.FromContext(r.Context()).WithValues("instanceID", s.instanceID)
+		logger.Error(err, "Error writing liveness response")
 	}
 }

--- a/cmd/maestro/server/logging/request_logging_middleware.go
+++ b/cmd/maestro/server/logging/request_logging_middleware.go
@@ -28,6 +28,10 @@ func RegisterLoggerMiddleware(ctx context.Context, router *mux.Router) {
 					logLevel = 4
 				}
 
+				if path == "/livez" {
+					logLevel = 4
+				}
+
 				reqCtx := r.Context()
 				logger := klog.FromContext(reqCtx)
 				loggingWriter := NewLoggingWriter(logger, w, r, NewJSONLogFormatter())


### PR DESCRIPTION
### What

Adds a dedicated process-only **`/livez`** liveness endpoint to `maestro-server`.

- `cmd/maestro/server/healthcheck_server.go` — register `GET /livez`; `livenessHandler` returns `200 OK` whenever the process can serve HTTP and **never touches Postgres**.
- `cmd/maestro/server/logging/request_logging_middleware.go` — `/livez` logs at level 4 (probe spam reduction), matching `/healthcheck`.

### Why

`/healthcheck` performs an instance-row `SELECT` against Postgres (DB error → HTTP 500/503). When the Kubernetes **liveness** probe is pointed at it, a transient Postgres slowdown becomes a self-reinforcing crash loop:

```text
/healthcheck SELECT slow/err
  -> liveness probe fails
  -> kubelet restarts the pod
  -> GORM pool closes ("sql: database is closed")
  -> reconnect storm makes Postgres worse
  -> Clusters Service gets 503 via the Istio sidecar
```

This was the root cause of a prod canary (`eastus2euap`) outage where HCP cluster creation timed out. With a process-only `/livez`, the liveness probe stays green during a recoverable DB blip and the pod is instead pulled from Service endpoints by the **readiness** probe (which keeps using `/healthcheck`). Maestro already supports multiple instances (heartbeat + advisory locks + dispatcher), so an up-but-not-DB-ready pod is correctly handled by readiness.

### Rollout note (why the chart probe is unchanged here)

This PR deliberately **does not** switch the chart's liveness probe to `/livez`. The `upgrade` CI job deploys the previous release image against the current chart; an older image 404s `/livez`, so flipping the probe path now would crash-loop the old pod (503s). Following the standard two-step probe rollout: ship the endpoint first, then switch the chart's liveness probe to `/livez` in a follow-up once a release that serves it is deployed. Consumers that manage their own manifests (e.g. ARO-HCP) can point their liveness probe at `/livez` as soon as they run an image built from this change.

### Testing

- `go build ./cmd/...` — passes.
- `go vet ./cmd/maestro/server/...` — passes.
- `helm template charts/maestro-server` — both probes still render `/healthcheck` (unchanged); the new image additionally serves `/livez`.

### Context

Upstream half of the deployment-layer hardening in Azure/ARO-HCP#5642. Ref: AROSLSRE-1170.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new liveness endpoint for real-time health monitoring that reports system availability status.

* **Improvements**
  * Standardized request logging behavior across all health check endpoints to provide consistent observability and reduce log noise from health-related monitoring requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->