### PR TITLE
add postgres_notification_queue_usage metric

### DIFF
--- a/pkg/controllers/framework.go
+++ b/pkg/controllers/framework.go
@@ -42,6 +42,10 @@ const EventID ControllerHandlerContextKey = "event"
 // events sync will help us to handle unexpected errors (e.g. sever restart), it ensures we will not miss any events
 var defaultEventsSyncPeriod = 10 * time.Hour
 
+// defaultNotificationQueueReportPeriod is the default period to report postgres notification queue usage (3 minutes)
+// This is done by running `SELECT pg_notification_queue_usage ()` against the db to retrieve the usage value.
+var defaultNotificationQueueReportPeriod = 3 * time.Minute
+
 type ControllerHandlerFunc func(ctx context.Context, id string) error
 
 type ControllerConfig struct {

--- a/pkg/controllers/metrics.go
+++ b/pkg/controllers/metrics.go
@@ -10,6 +10,7 @@ const (
 	specControllerMetricsSubsystem   = "spec_controller"
 	statusControllerMetricsSubsystem = "status_controller"
 	workqueueMetricsSubsystem        = "workqueue"
+	postgresMetricsSubsystem        = "postgres"
 )
 
 // Names of the metrics:
@@ -17,7 +18,7 @@ const (
 	eventReconcileTotalMetric     = "event_reconcile_total"
 	eventReconcileDurationMetric  = "event_reconcile_duration_seconds"
 	eventSyncOperationTotalMetric = "event_sync_operation_total"
-	NotificationQueueUsageMetric  = "postgres_notification_queue_usage"
+	notificationQueueUsageMetric  = "notification_queue_usage"
 	DepthMetric                   = "depth"
 	AddsTotalMetric               = "adds_total"
 	QueueDurationMetric           = "queue_duration_seconds"
@@ -123,8 +124,8 @@ var (
 	// notificationQueueUsage is a gauge of the current postgres notification queue usage:
 	notificationQueueUsage = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Subsystem: workqueueMetricsSubsystem,
-			Name:      NotificationQueueUsageMetric,
+			Subsystem: postgresMetricsSubsystem,
+			Name:      notificationQueueUsageMetric,
 			Help:      "Current usage of postgres notification queue",
 		},
 	)
@@ -209,7 +210,6 @@ var (
 
 	// workqueueMetrics is the list of all the workqueue metrics defined in this package:
 	workqueueMetrics = []prometheus.Collector{
-		notificationQueueUsage,
 		workqueueDepth,
 		workqueueAdds,
 		workqueueLatency,
@@ -228,6 +228,7 @@ func init() {
 	prometheus.MustRegister(statusEventReconciledTotal)
 	prometheus.MustRegister(statusEventReconcileDuration)
 	prometheus.MustRegister(statusControllerSyncEventOperationsTotal)
+	prometheus.MustRegister(notificationQueueUsage)
 
 	// Register the Prometheus workqueue metrics globally:
 	for _, metric := range workqueueMetrics {

--- a/pkg/controllers/metrics.go
+++ b/pkg/controllers/metrics.go
@@ -17,6 +17,7 @@ const (
 	eventReconcileTotalMetric     = "event_reconcile_total"
 	eventReconcileDurationMetric  = "event_reconcile_duration_seconds"
 	eventSyncOperationTotalMetric = "event_sync_operation_total"
+	NotificationQueueUsageMetric  = "postgres_notification_queue_usage"
 	DepthMetric                   = "depth"
 	AddsTotalMetric               = "adds_total"
 	QueueDurationMetric           = "queue_duration_seconds"
@@ -119,6 +120,15 @@ var (
 		[]string{controllerMetricsStatusLabel},
 	)
 
+	// notificationQueueUsage is a gauge of the current postgres notification queue usage:
+	notificationQueueUsage = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: workqueueMetricsSubsystem,
+			Name:      NotificationQueueUsageMetric,
+			Help:      "Current usage of postgres notification queue",
+		},
+	)
+
 	// workqueueDepth is a gauge of the current depth of workqueues, labeled by name:
 	workqueueDepth = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -199,6 +209,7 @@ var (
 
 	// workqueueMetrics is the list of all the workqueue metrics defined in this package:
 	workqueueMetrics = []prometheus.Collector{
+		notificationQueueUsage,
 		workqueueDepth,
 		workqueueAdds,
 		workqueueLatency,

--- a/pkg/controllers/status_controller.go
+++ b/pkg/controllers/status_controller.go
@@ -204,6 +204,7 @@ func batchStatusEventIDs(statusEventIDs []string, batchSize int) [][]string {
 	return batches
 }
 
+// reportNotificationQueueUsage reports the the usage of the postgres NOTIFY queue.
 func (sc *StatusController) reportNotificationQueueUsage(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	usage, err := sc.statusEvents.GetNotificationQueueUsage(ctx)

--- a/pkg/controllers/status_controller.go
+++ b/pkg/controllers/status_controller.go
@@ -204,7 +204,7 @@ func batchStatusEventIDs(statusEventIDs []string, batchSize int) [][]string {
 	return batches
 }
 
-// reportNotificationQueueUsage reports the the usage of the postgres NOTIFY queue.
+// reportNotificationQueueUsage reports the usage of the postgres NOTIFY queue.
 func (sc *StatusController) reportNotificationQueueUsage(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	usage, err := sc.statusEvents.GetNotificationQueueUsage(ctx)

--- a/pkg/controllers/status_controller.go
+++ b/pkg/controllers/status_controller.go
@@ -57,6 +57,8 @@ func (sc *StatusController) Run(ctx context.Context) {
 	// use a jitter to avoid multiple instances syncing the events at the same time
 	go wait.JitterUntilWithContext(ctx, sc.syncStatusEvents, defaultEventsSyncPeriod, 0.25, true)
 
+	go wait.JitterUntilWithContext(ctx, sc.reportNotificationQueueUsage, defaultNotificationQueueReportPeriod, 0.25, true)
+
 	// start a goroutine to handle the status event from the event queue
 	// the .Until will re-kick the runWorker one second after the runWorker completes
 	go wait.UntilWithContext(ctx, sc.runWorker, time.Second)
@@ -200,4 +202,17 @@ func batchStatusEventIDs(statusEventIDs []string, batchSize int) [][]string {
 		batches = append(batches, statusEventIDs[i:end])
 	}
 	return batches
+}
+
+func (sc *StatusController) reportNotificationQueueUsage(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	usage, err := sc.statusEvents.GetNotificationQueueUsage(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to get postgres notification queue usage")
+		return
+	}
+	if usage == nil {
+		return
+	}
+	notificationQueueUsage.Set(*usage)
 }

--- a/pkg/dao/status_event.go
+++ b/pkg/dao/status_event.go
@@ -21,6 +21,7 @@ type StatusEventDao interface {
 	DeleteAllReconciledEvents(ctx context.Context) error
 	DeleteAllEvents(ctx context.Context, eventIDs []string) error
 	FindAllUnreconciledEvents(ctx context.Context) (api.StatusEventList, error)
+	GetNotificationQueueUsage(ctx context.Context) (*float64, error)
 }
 
 var _ StatusEventDao = &sqlStatusEventDao{}
@@ -124,4 +125,17 @@ func (d *sqlStatusEventDao) All(ctx context.Context) (api.StatusEventList, error
 		return nil, err
 	}
 	return statusEvents, nil
+}
+
+func (d *sqlStatusEventDao) GetNotificationQueueUsage(ctx context.Context) (*float64, error) {
+	g2 := (*d.sessionFactory).New(ctx)
+	var usage *float64
+	result := g2.Raw("SELECT pg_notification_queue_usage()").
+		Scan(&usage)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return usage, nil
 }

--- a/pkg/services/status_event.go
+++ b/pkg/services/status_event.go
@@ -19,6 +19,7 @@ type StatusEventService interface {
 	FindAllUnreconciledEvents(ctx context.Context) (api.StatusEventList, *errors.ServiceError)
 	DeleteAllReconciledEvents(ctx context.Context) *errors.ServiceError
 	DeleteAllEvents(ctx context.Context, eventIDs []string) *errors.ServiceError
+	GetNotificationQueueUsage(ctx context.Context) (*float64, *errors.ServiceError)
 }
 
 func NewStatusEventService(statusEventDao dao.StatusEventDao) StatusEventService {
@@ -100,4 +101,12 @@ func (s *sqlStatusEventService) DeleteAllEvents(ctx context.Context, eventIDs []
 		return handleDeleteError("StatusEvent", errors.GeneralError("Unable to delete events %s: %s", eventIDs, err))
 	}
 	return nil
+}
+
+func (s *sqlStatusEventService) GetNotificationQueueUsage(ctx context.Context) (*float64, *errors.ServiceError) {
+	usage, err := s.statusEventDao.GetNotificationQueueUsage(ctx)
+	if err != nil {
+		return nil, errors.GeneralError("Unable to get notification queue usage: %s", err)
+	}
+	return usage, nil
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -675,4 +677,80 @@ func TestMultipleControllers(t *testing.T) {
 		return nil
 	}, 10*time.Second, 1*time.Second).Should(Succeed())
 
+}
+
+func TestNotificationQueueUsageMetric(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start a slow listener that deliberately delays notification consumption,
+	// causing notifications to accumulate in the postgres notification queue.
+	channel := "test_queue_usage_" + rand.String(5)
+	h.Env().Database.SessionFactory.NewListener(ctx, channel, func(id string) {
+		time.Sleep(100 * time.Second)
+	})
+
+	// Send NOTIFY's in a loop from a separate goroutine to fill the queue.
+	// The slow listener can only drain one notification every 10s, so the
+	// postgres NOTIFY queue usage will increase.
+	payload := strings.Repeat("x", 7000)
+	go func() {
+		notifyDB := h.Env().Database.SessionFactory.New(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				notifyDB.Exec(fmt.Sprintf("NOTIFY %s, '%s'", channel, payload))
+			}
+		}
+	}()
+
+	// Allow time for the notification queue to build up
+	time.Sleep(2 * time.Second)
+
+	// Start the StatusController, which calls reportNotificationQueueUsage on start
+	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
+	Expect(err).NotTo(HaveOccurred())
+	h.StartWorkAgent(ctx, consumer.Name)
+
+	go func() {
+		s := &server.ControllersServer{
+			KindControllerManager: controllers.NewKindControllerManager(
+				h.EventFilter,
+				h.Env().Services.Events(),
+			),
+			StatusController: controllers.NewStatusController(
+				h.Env().Services.StatusEvents(),
+				dao.NewInstanceDao(&h.Env().Database.SessionFactory),
+				dao.NewEventInstanceDao(&h.Env().Database.SessionFactory),
+			),
+		}
+		s.Start(ctx)
+	}()
+
+	// Wait for the metric to be reported with a value > 0, indicating
+	// that the notification queue has accumulated undelivered notifications.
+	metricName := "workqueue_postgres_notification_queue_usage"
+	Eventually(func() error {
+		gathered, gatherErr := prometheus.DefaultGatherer.Gather()
+		if gatherErr != nil {
+			return gatherErr
+		}
+		for _, mf := range gathered {
+			if *mf.Name == metricName {
+				if len(mf.Metric) == 0 {
+					return fmt.Errorf("metric %s has no samples", metricName)
+				}
+				usage := mf.Metric[0].Gauge.GetValue()
+				if usage <= 0 {
+					return fmt.Errorf("metric %s value %f is not > 0", metricName, usage)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("metric %s not found", metricName)
+	}, 10*time.Second, 1*time.Second).Should(Succeed())
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -696,6 +696,7 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 	// The slow listener can only drain one notification every 10s, so the
 	// postgres NOTIFY queue usage will increase.
 	payload := strings.Repeat("x", 7000)
+	var last_notify_err error 
 	go func() {
 		notifyDB := h.Env().Database.SessionFactory.New(ctx)
 		for {
@@ -703,7 +704,7 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				notifyDB.Exec(fmt.Sprintf("NOTIFY %s, '%s'", channel, payload))
+				last_notify_err = notifyDB.Exec(fmt.Sprintf("NOTIFY %s, '%s'", channel, payload)).Error
 			}
 		}
 	}()
@@ -752,5 +753,5 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 			}
 		}
 		return fmt.Errorf("metric %s not found", metricName)
-	}, 10*time.Second, 1*time.Second).Should(Succeed())
+	}, 10*time.Second, 1*time.Second).Should(Succeed(), "Last NOTIFY error: %v", last_notify_err)
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -704,7 +704,7 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				last_notify_err = notifyDB.Exec(fmt.Sprintf("NOTIFY %s, '%s'", channel, payload)).Error
+				last_notify_err = notifyDB.Exec("SELECT pg_notify(?, ?)", channel, payload).Error
 			}
 		}
 	}()

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -696,7 +697,8 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 	// The slow listener can only drain one notification every 10s, so the
 	// postgres NOTIFY queue usage will increase.
 	payload := strings.Repeat("x", 7000)
-	var last_notify_err error 
+	var mu sync.Mutex
+	var lastNotifyErr error
 	go func() {
 		notifyDB := h.Env().Database.SessionFactory.New(ctx)
 		for {
@@ -704,8 +706,12 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				last_notify_err = notifyDB.Exec("SELECT pg_notify(?, ?)", channel, payload).Error
+				err := notifyDB.Exec("SELECT pg_notify(?, ?)", channel, payload).Error
+				mu.Lock()
+				lastNotifyErr = err
+				mu.Unlock()
 			}
+			time.Sleep(time.Millisecond)
 		}
 	}()
 
@@ -734,7 +740,7 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 
 	// Wait for the metric to be reported with a value > 0, indicating
 	// that the notification queue has accumulated undelivered notifications.
-	metricName := "workqueue_postgres_notification_queue_usage"
+	metricName := "postgres_notification_queue_usage"
 	Eventually(func() error {
 		gathered, gatherErr := prometheus.DefaultGatherer.Gather()
 		if gatherErr != nil {
@@ -753,5 +759,9 @@ func TestNotificationQueueUsageMetric(t *testing.T) {
 			}
 		}
 		return fmt.Errorf("metric %s not found", metricName)
-	}, 10*time.Second, 1*time.Second).Should(Succeed(), "Last NOTIFY error: %v", last_notify_err)
+	}, 10*time.Second, 1*time.Second).Should(Succeed(), func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return fmt.Sprintf("Last NOTIFY error: %v", lastNotifyErr)
+	})
 }


### PR DESCRIPTION
## Description

This PR adds the postgres_notification_queue_usage metric, which is a gauge that reports the value returned from `SELECT pg_notification_queue_usage()` which is a percentage value from 0.0 to 1.0.

Each maestro server instance will report on this independently, but the value will reflect the usage of the global NOTIFY queue in the postgres instance.

Having this metric will enable alerts and dashboards for any issues that might cause the queue usage to increase (e.g. slow listener falling behind).

Note that placing the responsibility for the reporting of this metric in the StatusController/StatusEventDao is arbitrary.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

Unit, integration, and e2e tests pass.  Added a new integration test for the metric.

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring for PostgreSQL notification queue usage, including periodic reporting from the status controller to surface queue growth in metrics dashboards.

* **Tests**
  * Added an integration test that generates undelivered notifications via `LISTEN`/`pg_notify` and verifies the `postgres_notification_queue_usage` gauge is present and greater than zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->