### PR TITLE
Add operation label to GRPC server metrics

### DIFF
--- a/cmd/maestro/server/metrics_interceptor.go
+++ b/cmd/maestro/server/metrics_interceptor.go
@@ -6,17 +6,36 @@ import (
 	"strings"
 	"time"
 
+	ce "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
 	grpcprotocol "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 )
 
 func init() {
 	// Register the metrics:
 	RegisterGRPCMetrics()
+}
+
+// extractOperation extracts the operation name from a CloudEvent.
+// Returns the action from the CloudEvent type (e.g., "create", "update", "delete")
+// or "unknown" if the type cannot be parsed.
+func extractOperation(evt *ce.Event) string {
+	eventType, err := types.ParseCloudEventsType(evt.Type())
+	if err != nil {
+		return "unknown"
+	}
+	// Action is an EventAction type, convert to string
+	action := string(eventType.Action)
+	// Extract just the action part before "_request" if present
+	if strings.HasSuffix(action, "_request") {
+		action = strings.TrimSuffix(action, "_request")
+	}
+	return action
 }
 
 // NewMetricsUnaryInterceptor creates a unary server interceptor for server metrics.
@@ -39,19 +58,39 @@ func newMetricsUnaryInterceptor() grpc.UnaryServerInterceptor {
 			return nil, fmt.Errorf("failed to convert to cloudevent: %v", err)
 		}
 		source := evt.Source()
-		grpcCalledCountMetric.WithLabelValues(t, source).Inc()
 
+		// extract operation from CloudEvent type
+		operation := extractOperation(evt)
+
+		// Update existing metrics (backwards compatible)
+		grpcCalledCountMetric.WithLabelValues(t, source).Inc()
 		grpcMessageReceivedCountMetric.WithLabelValues(t, source).Inc()
+
+		// Update new operation-level metrics
+		grpcCalledCountByOperationMetric.WithLabelValues(t, source, operation).Inc()
+		grpcMessageReceivedCountByOperationMetric.WithLabelValues(t, source, operation).Inc()
+
 		startTime := time.Now()
 		resp, err := handler(ctx, req)
 		duration := time.Since(startTime).Seconds()
+
+		// Update existing metrics
 		grpcMessageSentCountMetric.WithLabelValues(t, source).Inc()
+
+		// Update new operation-level metrics
+		grpcMessageSentCountByOperationMetric.WithLabelValues(t, source, operation).Inc()
 
 		// get status code from error
 		status := statusFromError(err)
 		code := status.Code()
+
+		// Update existing metrics
 		grpcProcessedCountMetric.WithLabelValues(t, source, code.String()).Inc()
 		grpcProcessedDurationMetric.WithLabelValues(t, source).Observe(duration)
+
+		// Update new operation-level metrics
+		grpcProcessedCountByOperationMetric.WithLabelValues(t, source, operation, code.String()).Inc()
+		grpcProcessedDurationByOperationMetric.WithLabelValues(t, source, operation).Observe(duration)
 
 		return resp, err
 	}
@@ -75,8 +114,12 @@ func (w *wrappedMetricsStream) RecvMsg(m interface{}) error {
 		return fmt.Errorf("invalid request type for Subscribe method")
 	}
 	*w.source = subReq.Source
+	// Update existing metrics (backwards compatible)
 	grpcCalledCountMetric.WithLabelValues(w.t, subReq.Source).Inc()
 	grpcMessageReceivedCountMetric.WithLabelValues(w.t, subReq.Source).Inc()
+	// Update new operation-level metrics
+	grpcCalledCountByOperationMetric.WithLabelValues(w.t, subReq.Source, "subscribe").Inc()
+	grpcMessageReceivedCountByOperationMetric.WithLabelValues(w.t, subReq.Source, "subscribe").Inc()
 
 	return err
 }
@@ -84,7 +127,10 @@ func (w *wrappedMetricsStream) RecvMsg(m interface{}) error {
 // SendMsg wraps the SendMsg method of the embedded grpc.ServerStream.
 func (w *wrappedMetricsStream) SendMsg(m interface{}) error {
 	err := w.ServerStream.SendMsg(m)
+	// Update existing metrics (backwards compatible)
 	grpcMessageSentCountMetric.WithLabelValues(w.t, *w.source).Inc()
+	// Update new operation-level metrics
+	grpcMessageSentCountByOperationMetric.WithLabelValues(w.t, *w.source, "subscribe").Inc()
 	return err
 }
 
@@ -114,7 +160,10 @@ func newMetricsStreamInterceptor() grpc.StreamServerInterceptor {
 		// get status code from error
 		status := statusFromError(err)
 		code := status.Code()
+		// Update existing metrics (backwards compatible)
 		grpcProcessedCountMetric.WithLabelValues(t, source, code.String()).Inc()
+		// Update new operation-level metrics
+		grpcProcessedCountByOperationMetric.WithLabelValues(t, source, "subscribe", code.String()).Inc()
 
 		return err
 	}
@@ -136,21 +185,37 @@ const grpcMetricsSubsystem = "grpc_server"
 
 // Names of the labels added to metrics:
 const (
-	grpcMetricsTypeLabel   = "type"
-	grpcMetricsSourceLabel = "source"
-	grpcMetricsCodeLabel   = "code"
+	grpcMetricsTypeLabel      = "type"
+	grpcMetricsSourceLabel    = "source"
+	grpcMetricsCodeLabel      = "code"
+	grpcMetricsOperationLabel = "operation"
 )
 
-// grpcMetricsLabels - Array of labels added to metrics:
+// grpcMetricsLabels - Array of labels added to existing metrics:
 var grpcMetricsLabels = []string{
 	grpcMetricsTypeLabel,
 	grpcMetricsSourceLabel,
 }
 
-// grpcMetricsAllLabels - Array of all labels added to metrics:
+// grpcMetricsAllLabels - Array of all labels added to existing metrics:
 var grpcMetricsAllLabels = []string{
 	grpcMetricsTypeLabel,
 	grpcMetricsSourceLabel,
+	grpcMetricsCodeLabel,
+}
+
+// grpcMetricsLabelsWithOperation - Array of labels for new operation-level metrics:
+var grpcMetricsLabelsWithOperation = []string{
+	grpcMetricsTypeLabel,
+	grpcMetricsSourceLabel,
+	grpcMetricsOperationLabel,
+}
+
+// grpcMetricsAllLabelsWithOperation - Array of all labels for new operation-level metrics:
+var grpcMetricsAllLabelsWithOperation = []string{
+	grpcMetricsTypeLabel,
+	grpcMetricsSourceLabel,
+	grpcMetricsOperationLabel,
 	grpcMetricsCodeLabel,
 }
 
@@ -161,15 +226,28 @@ const (
 	processedDurationMetric    = "processed_duration_seconds"
 	messageReceivedCountMetric = "message_received_total"
 	messageSentCountMetric     = "message_sent_total"
+	// New operation-level metrics (non-breaking)
+	calledCountByOperationMetric          = "called_total_by_operation"
+	processedCountByOperationMetric       = "processed_total_by_operation"
+	processedDurationByOperationMetric    = "processed_duration_seconds_by_operation"
+	messageReceivedCountByOperationMetric = "message_received_total_by_operation"
+	messageSentCountByOperationMetric     = "message_sent_total_by_operation"
 )
 
 // Register the metrics:
 func RegisterGRPCMetrics() {
+	// Register existing metrics (backwards compatible)
 	prometheus.MustRegister(grpcCalledCountMetric)
 	prometheus.MustRegister(grpcProcessedCountMetric)
 	prometheus.MustRegister(grpcProcessedDurationMetric)
 	prometheus.MustRegister(grpcMessageReceivedCountMetric)
 	prometheus.MustRegister(grpcMessageSentCountMetric)
+	// Register new operation-level metrics
+	prometheus.MustRegister(grpcCalledCountByOperationMetric)
+	prometheus.MustRegister(grpcProcessedCountByOperationMetric)
+	prometheus.MustRegister(grpcProcessedDurationByOperationMetric)
+	prometheus.MustRegister(grpcMessageReceivedCountByOperationMetric)
+	prometheus.MustRegister(grpcMessageSentCountByOperationMetric)
 }
 
 // Unregister the metrics:
@@ -179,6 +257,11 @@ func UnregisterGRPCMetrics() {
 	prometheus.Unregister(grpcProcessedDurationMetric)
 	prometheus.Unregister(grpcMessageReceivedCountMetric)
 	prometheus.Unregister(grpcMessageSentCountMetric)
+	prometheus.Unregister(grpcCalledCountByOperationMetric)
+	prometheus.Unregister(grpcProcessedCountByOperationMetric)
+	prometheus.Unregister(grpcProcessedDurationByOperationMetric)
+	prometheus.Unregister(grpcMessageReceivedCountByOperationMetric)
+	prometheus.Unregister(grpcMessageSentCountByOperationMetric)
 }
 
 // Reset the metrics:
@@ -188,6 +271,11 @@ func ResetGRPCMetrics() {
 	grpcProcessedDurationMetric.Reset()
 	grpcMessageReceivedCountMetric.Reset()
 	grpcMessageSentCountMetric.Reset()
+	grpcCalledCountByOperationMetric.Reset()
+	grpcProcessedCountByOperationMetric.Reset()
+	grpcProcessedDurationByOperationMetric.Reset()
+	grpcMessageReceivedCountByOperationMetric.Reset()
+	grpcMessageSentCountByOperationMetric.Reset()
 }
 
 // Description of the gRPC called count metric:
@@ -239,4 +327,57 @@ var grpcMessageSentCountMetric = prometheus.NewCounterVec(
 		Help:      "Total number of messages sent by the server to agent and client.",
 	},
 	grpcMetricsLabels,
+)
+
+// New operation-level metrics (non-breaking additions):
+
+// Description of the gRPC called count metric by operation:
+var grpcCalledCountByOperationMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: grpcMetricsSubsystem,
+		Name:      calledCountByOperationMetric,
+		Help:      "Total number of RPCs called on the server, by operation type.",
+	},
+	grpcMetricsLabelsWithOperation,
+)
+
+// Description of the gRPC processed count metric by operation:
+var grpcProcessedCountByOperationMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: grpcMetricsSubsystem,
+		Name:      processedCountByOperationMetric,
+		Help:      "Total number of RPCs processed on the server by operation type, regardless of success or failure.",
+	},
+	grpcMetricsAllLabelsWithOperation,
+)
+
+// Description of the gRPC processed duration metric by operation:
+var grpcProcessedDurationByOperationMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Subsystem: grpcMetricsSubsystem,
+		Name:      processedDurationByOperationMetric,
+		Help:      "Histogram of the duration of RPCs processed on the server by operation type.",
+		Buckets:   prometheus.DefBuckets,
+	},
+	grpcMetricsLabelsWithOperation,
+)
+
+// Description of the gRPC message received count metric by operation:
+var grpcMessageReceivedCountByOperationMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: grpcMetricsSubsystem,
+		Name:      messageReceivedCountByOperationMetric,
+		Help:      "Total number of messages received on the server from agent and client, by operation type.",
+	},
+	grpcMetricsLabelsWithOperation,
+)
+
+// Description of the gRPC message sent count metric by operation:
+var grpcMessageSentCountByOperationMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: grpcMetricsSubsystem,
+		Name:      messageSentCountByOperationMetric,
+		Help:      "Total number of messages sent by the server to agent and client, by operation type.",
+	},
+	grpcMetricsLabelsWithOperation,
 )


### PR DESCRIPTION
# Add operation-level GRPC server metrics (non-breaking)

## Summary

Adds new operation-level GRPC server metrics alongside existing metrics to provide detailed observability into Maestro server operations. This addresses the need for operation-level monitoring identified in ARO-26754.

**✅ NON-BREAKING CHANGE**: Creates NEW metrics with `_by_operation` suffix instead of modifying existing metrics.

## Changes

### Modified Files

**cmd/maestro/server/metrics_interceptor.go**:
- Added 5 new metrics with `_by_operation` suffix
- Implemented `extractOperation()` helper to parse CloudEvent type
- Updated interceptors to populate BOTH old and new metrics
- Added imports for CloudEvent type parsing

### New Metrics Added (Non-Breaking)

All new metrics include `operation` label and use `_by_operation` suffix:

1. **grpc_server_called_total_by_operation** - Counter
   - Labels: `type`, `source`, `operation`
   - Help: "Total number of RPCs called on the server, by operation type."

2. **grpc_server_processed_total_by_operation** - Counter
   - Labels: `type`, `source`, `operation`, `code`
   - Help: "Total number of RPCs processed on the server by operation type, regardless of success or failure."

3. **grpc_server_processed_duration_seconds_by_operation** - Histogram
   - Labels: `type`, `source`, `operation`
   - Help: "Histogram of the duration of RPCs processed on the server by operation type."

4. **grpc_server_message_received_total_by_operation** - Counter
   - Labels: `type`, `source`, `operation`
   - Help: "Total number of messages received on the server from agent and client, by operation type."

5. **grpc_server_message_sent_total_by_operation** - Counter
   - Labels: `type`, `source`, `operation`
   - Help: "Total number of messages sent by the server to agent and client, by operation type."

### Existing Metrics (Unchanged, Backwards Compatible)

These metrics continue to work exactly as before:

1. **grpc_server_called_total** - Counter with labels: `type`, `source`
2. **grpc_server_processed_total** - Counter with labels: `type`, `source`, `code`
3. **grpc_server_processed_duration_seconds** - Histogram with labels: `type`, `source`
4. **grpc_server_message_received_total** - Counter with labels: `type`, `source`
5. **grpc_server_message_sent_total** - Counter with labels: `type`, `source`

### Operation Values

**Publish method** (extracted from CloudEvent type):
- `create` - Create resource request
- `update` - Update resource request
- `delete` - Delete resource request
- `resync` - Resync status request
- `unknown` - Parse error fallback

**Subscribe method**:
- `subscribe` - Subscribe to resource status updates

## Implementation Details

### Dual Metrics Population

Both old and new metrics are populated in the same code path:

```go
// Update existing metrics (backwards compatible)
grpcCalledCountMetric.WithLabelValues(t, source).Inc()

// Update new operation-level metrics
grpcCalledCountByOperationMetric.WithLabelValues(t, source, operation).Inc()
```

### Performance Impact

- **Negligible overhead**: Both metrics updated in the same code execution
- **No additional parsing**: Operation extracted once and reused
- **No latency increase**: Metrics population is already very fast

## Testing

### Build Verification
- ✅ `make binary` - Successfully compiled (140MB binary)
- ✅ No lint or format issues
- ✅ All imports resolved correctly

### Expected Metrics Output

**Existing metrics (continue working)**:
```
grpc_server_called_total{type="Publish",source="aro-hcp-clusters-service"} 65
grpc_server_processed_total{type="Publish",source="aro-hcp-clusters-service",code="OK"} 65
grpc_server_processed_duration_seconds_sum{type="Publish",source="aro-hcp-clusters-service"} 3.2
```

**New metrics (added)**:
```
grpc_server_called_total_by_operation{type="Publish",source="aro-hcp-clusters-service",operation="create"} 42
grpc_server_called_total_by_operation{type="Publish",source="aro-hcp-clusters-service",operation="update"} 18
grpc_server_called_total_by_operation{type="Publish",source="aro-hcp-clusters-service",operation="delete"} 5

grpc_server_processed_total_by_operation{type="Publish",source="aro-hcp-clusters-service",operation="create",code="OK"} 42
grpc_server_processed_duration_seconds_by_operation_sum{type="Publish",source="aro-hcp-clusters-service",operation="create"} 2.1
```

## Backwards Compatibility

✅ **100% Backwards Compatible**

- **Existing dashboards**: Continue working without any changes
- **Existing alerts**: Continue working without any changes
- **Existing queries**: Continue working without any changes
- **No migration required**: Consumers can adopt new metrics at their own pace

### Migration Path (Optional)

Consumers can gradually migrate to the new operation-level metrics:

**Phase 1** (after this PR merges):
- Existing metrics continue working
- New metrics become available
- Dashboards can start using new metrics

**Phase 2** (gradual migration):
- Update dashboards to use `_by_operation` metrics
- Create new alerts using operation-level detail
- Test and validate

**Phase 3** (future, optional):
- Deprecate old metrics (with advance notice)
- Eventually remove old metrics (6-12 months later)

## Benefits

1. **Operation-level visibility**: Distinguish Create vs Update vs Delete performance
2. **Targeted debugging**: Identify which operations are slow or failing
3. **Capacity planning**: Understand operation distribution patterns
4. **Consumer analysis**: Track which consumers use which operations
5. **Better alerting**: Create operation-specific SLOs
6. **Zero disruption**: Existing monitoring continues working

## Example Use Cases

**Which operation is slowest?**
```promql
histogram_quantile(0.95, 
  sum by (operation, le) (
    rate(grpc_server_processed_duration_seconds_by_operation_bucket[5m])
  )
)
```

**Which consumer creates the most resources?**
```promql
sum by (source) (
  rate(grpc_server_called_total_by_operation{operation="create"}[5m])
)
```

**Are deletes failing more than creates?**
```promql
sum by (operation) (
  rate(grpc_server_processed_total_by_operation{code!="OK"}[5m])
) 
/ 
sum by (operation) (
  rate(grpc_server_processed_total_by_operation[5m])
)
```

**Compare old vs new metrics (validation)**:
```promql
# Should be equal:
sum(rate(grpc_server_called_total[5m]))
  ==
sum(rate(grpc_server_called_total_by_operation[5m]))
```

## Deployment

✅ **No coordination required** - can deploy independently

- Deploy this PR at any time
- Dashboard updates can deploy before or after
- No downtime or migration window needed

## Related

- **Jira**: [ARO-26754](https://issues.redhat.com/browse/ARO-26754) - Add Maestro GRPC metrics instrumentation
- **Root Cause**: ARO-26043 - Cluster provisioning latency investigation
- **Dashboard PR**: https://github.com/Azure/ARO-HCP/pull/6019

## Reviewers

Please review:
1. ✅ Non-breaking approach (new metrics alongside old)
2. ✅ Operation extraction logic from CloudEvent type
3. ✅ Dual metrics population in interceptors
4. ✅ Naming convention (`_by_operation` suffix)
5. ✅ Performance impact (minimal - same code path)

## Checklist

- [x] Code follows Maestro repository patterns
- [x] Metrics naming follows Prometheus best practices
- [x] Added 5 new metrics with `_by_operation` suffix
- [x] Existing metrics unchanged and continue working
- [x] Both old and new metrics populated in interceptors
- [x] Build passes successfully
- [x] No new dependencies added
- [x] **Non-breaking change** - backwards compatible
- [x] No migration required for existing consumers
- [x] No deployment coordination needed
