### PR TITLE
fix(server): stop orphaning applied resources on resource-bundle delete (ARO-28432)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,10 +174,11 @@ verify: check-gopath verify-fmt-imports
 .PHONY: verify
 
 # Runs our linter to verify that everything is following best practices
-# Requires golangci-lint to be installed @ $(go env GOPATH)/bin/golangci-lint
+# Requires golangci-lint (v2, since go.mod requires go >= 1.25 which is only supported by
+# golangci-lint v2) to be installed @ $(go env GOPATH)/bin/golangci-lint
 # Linter is set to ignore `unused` stuff due to example being incomplete by definition
 lint:
-	$(GOLANGCI_LINT_BIN) run -e unused \
+	$(GOLANGCI_LINT_BIN) run -D unused \
 		./cmd/... \
 		./pkg/...
 .PHONY: lint

--- a/charts/maestro-agent/templates/crd.yaml
+++ b/charts/maestro-agent/templates/crd.yaml
@@ -83,10 +83,10 @@ spec:
       storage: true
       subresources:
         status: {}
-  status:
-    acceptedNames:
-      kind: ""
-      plural: ""
-    conditions: []
-    storedVersions: []
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 {{- end }}

--- a/cmd/maestro/server/grpc_broker.go
+++ b/cmd/maestro/server/grpc_broker.go
@@ -215,17 +215,43 @@ func (bkr *GRPCBroker) Start(ctx context.Context) {
 
 // OnCreate is called by the controller when a resource is created on the maestro server.
 func (s *GRPCBroker) OnCreate(ctx context.Context, resourceID string) error {
-	evt, err := s.Get(ctx, resourceID, types.CreateRequestAction)
+	logger := klog.FromContext(ctx).WithValues("resourceID", resourceID)
+
+	resource, svcErr := s.resourceService.Get(ctx, resourceID)
+	if svcErr != nil {
+		if svcErr.Is404() {
+			logger.Info("skipping to publish create request for resource as it is not found")
+			return nil
+		}
+		return kubeerrors.NewInternalError(svcErr)
+	}
+
+	if !resource.Meta.DeletedAt.Time.IsZero() {
+		// The resource is already marked as deleting. Do NOT assume it was never sent to the
+		// agent: this Create event may be a stale/retried event for a resource that was already
+		// successfully delivered to (and applied by) the agent through another path. Skip this
+		// create; the corresponding delete event will propagate the delete_request.
+		logger.Info("skipping create for resource that is marked as deleting; the delete event will propagate the delete")
+		return nil
+	}
+
+	evt, err := EncodeResourceSpec(resource, types.CreateRequestAction)
 	if err != nil {
-		return err
+		return kubeerrors.NewInternalError(err)
 	}
 	return s.eventServer.HandleEvent(ctx, evt)
 }
 
 // OnUpdate is called by the controller when a resource is updated on the maestro server.
 func (s *GRPCBroker) OnUpdate(ctx context.Context, resourceID string) error {
+	logger := klog.FromContext(ctx).WithValues("resourceID", resourceID)
+
 	evt, err := s.Get(ctx, resourceID, types.UpdateRequestAction)
 	if err != nil {
+		if kubeerrors.IsNotFound(err) {
+			logger.Info("skipping to publish update request for resource as it is not found")
+			return nil
+		}
 		return err
 	}
 	return s.eventServer.HandleEvent(ctx, evt)
@@ -233,8 +259,14 @@ func (s *GRPCBroker) OnUpdate(ctx context.Context, resourceID string) error {
 
 // OnDelete is called by the controller when a resource is deleted from the maestro server.
 func (s *GRPCBroker) OnDelete(ctx context.Context, resourceID string) error {
+	logger := klog.FromContext(ctx).WithValues("resourceID", resourceID)
+
 	evt, err := s.Get(ctx, resourceID, types.DeleteRequestAction)
 	if err != nil {
+		if kubeerrors.IsNotFound(err) {
+			logger.Info("skipping to publish delete request for resource as it is not found")
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/maestro/server/grpc_broker_test.go
+++ b/cmd/maestro/server/grpc_broker_test.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/server"
+
+	ce "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/errors"
+	"github.com/openshift-online/maestro/pkg/services"
+)
+
+// testPayload builds a minimal, valid CloudEvent-shaped payload usable as a resource's Payload.
+func testPayload(t *testing.T) datatypes.JSONMap {
+	t.Helper()
+	data := `{
+		"id":"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8",
+		"time":"2024-02-05T17:31:05Z",
+		"type":"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request",
+		"source":"grpc",
+		"specversion":"1.0",
+		"datacontenttype":"application/json",
+		"resourceid":"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4",
+		"clustername":"cluster1",
+		"resourceversion":1,
+		"data":{"manifests":[{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"nginx","namespace":"default"}}]}
+	}`
+	payload := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+// fakeAgentEventServer is a minimal implementation of server.AgentEventServer used to observe
+// whether HandleEvent (i.e. publishing to the agent) was invoked.
+type fakeAgentEventServer struct {
+	handledEvents []*ce.Event
+}
+
+func (f *fakeAgentEventServer) HandleEvent(_ context.Context, evt *ce.Event) error {
+	f.handledEvents = append(f.handledEvents, evt)
+	return nil
+}
+
+func (f *fakeAgentEventServer) RegisterService(_ context.Context, _ types.CloudEventsDataType, _ server.Service) {
+}
+
+func (f *fakeAgentEventServer) Subscribers() sets.Set[string] {
+	return sets.New[string]()
+}
+
+// fakeResourceService is a configurable mock of services.ResourceService used to test
+// GRPCBroker's OnCreate/OnUpdate/OnDelete handlers in isolation.
+type fakeResourceService struct {
+	services.ResourceService
+	resource *api.Resource
+	getErr   *errors.ServiceError
+}
+
+func (m *fakeResourceService) Get(_ context.Context, _ string) (*api.Resource, *errors.ServiceError) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.resource, nil
+}
+
+// TestGRPCBrokerOnCreateSkipsResourceMarkedAsDeleting verifies that OnCreate does not publish a
+// create_request to the agent for a resource that is already marked as deleting. This guards
+// against ARO-28432, where sending (or worse, hard-deleting without notifying the agent) for a
+// stale/retried Create event orphaned resources already applied on the managed cluster.
+func TestGRPCBrokerOnCreateSkipsResourceMarkedAsDeleting(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta: api.Meta{
+			ID:        "res-1",
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+		ConsumerName: "cluster1",
+	}
+	fakeSvc := &fakeResourceService{resource: resource}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnCreate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(BeEmpty(), "OnCreate must not publish create_request for a resource marked as deleting")
+}
+
+// TestGRPCBrokerOnCreateSkipsWhenResourceNotFound verifies OnCreate is a no-op (not an error)
+// when the resource has already been hard-deleted.
+func TestGRPCBrokerOnCreateSkipsWhenResourceNotFound(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeSvc := &fakeResourceService{getErr: errors.NotFound("resource not found")}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnCreate(context.Background(), "missing-id")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(BeEmpty())
+}
+
+// TestGRPCBrokerOnCreatePublishesForNormalResource verifies OnCreate publishes a create_request
+// for a resource that is not marked as deleting.
+func TestGRPCBrokerOnCreatePublishesForNormalResource(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta:         api.Meta{ID: "res-2"},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resource: resource}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnCreate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(HaveLen(1))
+}
+
+// TestGRPCBrokerOnDeleteSkipsWhenResourceNotFound verifies OnDelete returns nil (allowing the
+// event to be reconciled) instead of an error when the resource has already been hard-deleted,
+// preventing infinite retries of the delete event.
+func TestGRPCBrokerOnDeleteSkipsWhenResourceNotFound(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeSvc := &fakeResourceService{getErr: errors.NotFound("resource not found")}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnDelete(context.Background(), "missing-id")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(BeEmpty())
+}
+
+// TestGRPCBrokerOnUpdateSkipsWhenResourceNotFound verifies OnUpdate returns nil instead of an
+// error when the resource has already been hard-deleted.
+func TestGRPCBrokerOnUpdateSkipsWhenResourceNotFound(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeSvc := &fakeResourceService{getErr: errors.NotFound("resource not found")}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnUpdate(context.Background(), "missing-id")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(BeEmpty())
+}
+
+// TestGRPCBrokerOnDeletePublishesForExistingResource verifies OnDelete publishes a
+// delete_request for a resource that still exists and is marked as deleting.
+func TestGRPCBrokerOnDeletePublishesForExistingResource(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta: api.Meta{
+			ID:        "res-3",
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resource: resource}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnDelete(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(HaveLen(1))
+}

--- a/cmd/maestro/server/grpc_broker_test.go
+++ b/cmd/maestro/server/grpc_broker_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
+	ce "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/gomega"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/server"
-
-	ce "github.com/cloudevents/sdk-go/v2"
 
 	"github.com/openshift-online/maestro/pkg/api"
 	"github.com/openshift-online/maestro/pkg/errors"

--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -77,8 +77,16 @@ func (s *SourceClientImpl) OnCreate(ctx context.Context, id string) error {
 	}
 
 	if !resource.Meta.DeletedAt.Time.IsZero() {
-		logger.Info("delete resource as it is not created on the agent yet")
-		return s.ResourceService.Delete(ctx, id)
+		// The resource is already marked as deleting. Do NOT assume it was never sent to the
+		// agent and hard-delete it here: this Create event may be a stale/retried event for a
+		// resource that was already successfully delivered to (and applied by) the agent through
+		// another path (e.g. a prior successful publish whose event wasn't marked reconciled, a
+		// resync, or an update). Hard-deleting here would silently drop the delete without ever
+		// notifying the agent, orphaning the applied resource on the managed cluster.
+		// Skip this create; the corresponding delete event will publish the delete_request and
+		// the resource will be hard-deleted once the agent confirms deletion.
+		logger.Info("skipping create for resource that is marked as deleting; the delete event will propagate the delete")
+		return nil
 	}
 
 	logger.Info("Publishing resource for db row insert")

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
+
 	. "github.com/onsi/gomega"
 	ceoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	cepayload "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
@@ -91,6 +94,72 @@ func newTestSourceClient(transport *mockTransport, resources []*api.Resource) *S
 		sourceID:        "test-source",
 		transport:       transport,
 	}
+}
+
+// getDeleteMockResourceService is a mock used to test OnCreate/OnDelete behavior. It allows
+// configuring the resource returned by Get and tracks whether Delete was called.
+type getDeleteMockResourceService struct {
+	services.ResourceService
+	resource     *api.Resource
+	getErr       *errors.ServiceError
+	deleteCalled bool
+}
+
+func (m *getDeleteMockResourceService) Get(_ context.Context, _ string) (*api.Resource, *errors.ServiceError) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.resource, nil
+}
+
+func (m *getDeleteMockResourceService) Delete(_ context.Context, _ string) *errors.ServiceError {
+	m.deleteCalled = true
+	return nil
+}
+
+// TestOnCreateSkipsHardDeleteForResourceMarkedAsDeleting verifies that OnCreate does NOT
+// hard-delete a resource (and thus does not drop the delete without notifying the agent) when
+// the resource is already marked as deleting (DeletedAt set). This guards against ARO-28432,
+// where a stale/retried Create event caused the server to silently hard-delete a resource that
+// had already been delivered to and applied by the agent, orphaning it on the managed cluster.
+func TestOnCreateSkipsHardDeleteForResourceMarkedAsDeleting(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta: api.Meta{
+			ID:        uuid.New().String(),
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+	}
+	mockSvc := &getDeleteMockResourceService{resource: resource}
+	client := &SourceClientImpl{
+		Codec:           NewCodec("test-source"),
+		ResourceService: mockSvc,
+		sourceID:        "test-source",
+		transport:       &mockTransport{},
+	}
+
+	err := client.OnCreate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockSvc.deleteCalled).To(BeFalse(), "OnCreate must not hard-delete a resource marked as deleting; the delete event must propagate the delete to the agent instead")
+}
+
+// TestOnCreateSkipsWhenResourceNotFound verifies OnCreate is a no-op when the resource has
+// already been hard-deleted (404).
+func TestOnCreateSkipsWhenResourceNotFound(t *testing.T) {
+	RegisterTestingT(t)
+
+	mockSvc := &getDeleteMockResourceService{getErr: errors.NotFound("resource not found")}
+	client := &SourceClientImpl{
+		Codec:           NewCodec("test-source"),
+		ResourceService: mockSvc,
+		sourceID:        "test-source",
+		transport:       &mockTransport{},
+	}
+
+	err := client.OnCreate(context.Background(), uuid.New().String())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockSvc.deleteCalled).To(BeFalse())
 }
 
 func decodeHashList(evt cloudevents.Event) *cepayload.ResourceStatusHashList {

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -8,9 +8,8 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
-	"gorm.io/gorm"
-
 	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
 	ceoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	cepayload "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/payload"
 	cetypes "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -472,6 +472,69 @@ func TestMarkAsDeletingThenUpdate(t *testing.T) {
 	Expect(len(res.Status)).ShouldNot(Equal(0))
 }
 
+// TestOnCreateDoesNotOrphanResourceMarkedAsDeleting is a regression test for ARO-28432: Maestro
+// server dropped a resource-bundle delete without ever propagating it to the agent, orphaning the
+// applied resource on the managed cluster.
+//
+// Root cause: SourceClientImpl.OnCreate (the handler invoked by the event controller when
+// processing a CreateEventType event) assumed that if the resource is already marked as deleting
+// (DeletedAt set) by the time its Create event is processed, the agent could never have received
+// it, and hard-deleted the resource from the database without notifying the agent. That assumption
+// is false whenever the Create event being processed is stale/retried (e.g. re-queued after a
+// transient publish failure) for a resource that was already delivered to, and is being actively
+// managed by, the agent through another path.
+//
+// This test reproduces the scenario directly against the real (test) EventServer and database:
+//  1. create a resource (Version=1)
+//  2. simulate the agent having already applied it and reported status back to maestro
+//  3. mark the resource as deleting (as the DELETE API handler would)
+//  4. invoke EventServer.OnCreate for the resource, simulating a stale/retried Create event being
+//     processed after the deletion was requested
+//
+// Before the fix, step 4 would hard-delete the resource (via ResourceService.Delete) with no
+// propagation to the agent. After the fix, OnCreate must skip and leave the resource soft-deleted,
+// so the Delete event handler can still propagate the delete_request to the agent.
+func TestOnCreateDoesNotOrphanResourceMarkedAsDeleting(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx := context.Background()
+
+	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
+	Expect(err).NotTo(HaveOccurred())
+	deployName := fmt.Sprintf("nginx-%s", rand.String(5))
+	resource, err := h.CreateResource(uuid.NewString(), consumer.Name, deployName, "default", 1)
+	Expect(err).NotTo(HaveOccurred())
+
+	resourceService := h.Env().Services.Resources()
+
+	// Simulate the agent having already received and applied the resource, and reported status
+	// back to maestro, even though the Create event for it may not yet be marked reconciled.
+	statusRes := &api.Resource{
+		Meta:    api.Meta{ID: resource.ID},
+		Version: resource.Version,
+		Status:  createStatusWithSequenceID(t, resource.ID, "1"),
+	}
+	_, updated, svcErr := resourceService.UpdateStatus(ctx, statusRes)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(updated).Should(BeTrue())
+
+	// The user requests deletion before the (stale/retried) Create event is processed.
+	svcErr2 := resourceService.MarkAsDeleting(ctx, resource.ID)
+	Expect(svcErr2).NotTo(HaveOccurred())
+
+	// Simulate the event controller processing a stale/retried Create event for this resource.
+	Expect(h.EventServer.OnCreate(ctx, resource.ID)).To(Succeed())
+
+	// The resource must NOT have been hard-deleted: it must still exist, still marked as
+	// deleting, so the Delete event handler can propagate the delete_request to the agent.
+	res, svcErr3 := resourceService.Get(ctx, resource.ID)
+	Expect(svcErr3).NotTo(HaveOccurred())
+	Expect(res.DeletedAt.Valid).To(BeTrue(), "resource must remain (soft-deleted) so the delete can still be propagated to the agent")
+
+	// The Delete event handler must still be able to process the deletion normally afterwards.
+	Expect(h.EventServer.OnDelete(ctx, resource.ID)).To(Succeed())
+}
+
 func updateWorkStatus(ctx context.Context, workClient workv1client.ManifestWorkInterface, work *workv1.ManifestWork, newStatus workv1.ManifestWorkStatus) error {
 	// update the work status
 	newWork := work.DeepCopy()


### PR DESCRIPTION
## Description

On a resource-bundle `DELETE`, Maestro server could remove the bundle from its own
database and return success to the client without ever propagating the delete to the
agent, leaving the applied `ManifestWork` (and everything it deploys) orphaned on the
managed cluster.

**Root cause:** `SourceClientImpl.OnCreate` — the handler invoked by the event
controller when processing a `CreateEventType` event — assumed that if the resource
was already marked as deleting (`DeletedAt` set) by the time its `Create` event was
processed, the agent could never have received it, and hard-deleted the resource from
the database with no propagation to the agent. That assumption is false whenever the
`Create` event being processed is stale or retried (e.g. re-queued after a transient
publish failure) for a resource that was already delivered to, and is being actively
managed by, the agent through another path. In production this caused Maestro to
report a delete as successful while the ManifestWork (a HostedCluster/HostedControlPlane
bundle) remained live on the management cluster, cascading into a permanently stuck
cluster deletion.

**Fix:** `OnCreate` now skips (does not hard-delete) when the resource is already
marked as deleting, deferring to the `Delete` event handler to propagate the
`delete_request` to the agent. The same `DeletedAt` guard is applied to
`GRPCBroker.OnCreate` for consistency with the MQTT source-client path, and
`GRPCBroker.OnDelete`/`OnUpdate` now treat a 404 as a no-op instead of an error to
avoid infinite event retries.

Two additional fixes were needed to validate this change end-to-end and are included
here:
- `Makefile`: the `lint` target used the golangci-lint v1 `-e` flag, which is
  incompatible with the v2 binary required now that `go.mod` declares `go 1.25.0`
  (no golangci-lint v1 release supports go1.25+).
- `charts/maestro-agent/templates/crd.yaml`: the `AppliedManifestWork` CRD's
  top-level `status` block was mis-indented under `spec`, which made Helm's
  server-side apply reject the CRD (`unknown field "spec.status"`) and blocked
  `maestro-agent` from installing on any fresh cluster.

Jira: [ARO-28432](https://redhat.atlassian.net/browse/ARO-28432)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or tooling change (Makefile lint flag, chart CRD fix)

## Testing

- Added `TestOnCreateDoesNotOrphanResourceMarkedAsDeleting` (`test/integration/resource_test.go`),
  an integration test against the real DB/event server/MQTT broker that reproduces the exact
  ARO-28432 failure on the pre-fix code (`404 not found` after silent hard-delete) and passes
  with the fix.
- Added unit tests for `SourceClientImpl.OnCreate` (`pkg/client/cloudevents/source_client_test.go`)
  and `GRPCBroker.OnCreate/OnUpdate/OnDelete` (`cmd/maestro/server/grpc_broker_test.go`).
- `make test` — full unit suite passes.
- `make test-integration` (mqtt) — passes, excluding one pre-existing/flaky
  `TestNotificationQueueUsageMetric` confirmed unrelated (fails identically on `main`).
- `make lint` — now runs (was broken by the go1.25/golangci-lint v1-v2 mismatch); reports the
  same 69 pre-existing issues as `main`, zero new issues introduced by this change.
- `make e2e-test` — full suite passes: 40/40 specs, 0 failed.

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (if applicable)
- [x] Manual verification completed (full e2e suite: 40/40 passed)

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale or repeated create events from incorrectly deleting resources already marked for deletion.
  * Improved handling of missing resources by safely ignoring outdated create, update, and delete events.
  * Ensured valid resource events continue to be delivered correctly.
  * Added safeguards to prevent resources from becoming orphaned during deletion workflows.

* **Chores**
  * Updated linting guidance and configuration for the required tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->