### PR TITLE
fix: prevent Delete-event starvation of the spec controller (AROSLSRE-1547)

### DIFF
--- a/cmd/maestro/server/controllers.go
+++ b/cmd/maestro/server/controllers.go
@@ -50,6 +50,15 @@ func NewControllersServer(ctx context.Context, eventServer EventServer, eventFil
 				threshold,
 			)
 		}
+
+		staleDeleteThreshold := env().Config.EventServer.StaleDeleteEventThreshold
+		if staleDeleteThreshold > 0 {
+			s.StaleDeleteDetector = controllers.NewStaleDeleteDetector(
+				env().Services.Events(),
+				db.NewAdvisoryLockFactory(env().Database.SessionFactory),
+				staleDeleteThreshold,
+			)
+		}
 	}
 
 	s.StatusController.Add(map[api.StatusEventType][]controllers.StatusHandlerFunc{
@@ -64,6 +73,7 @@ type ControllersServer struct {
 	KindControllerManager *controllers.KindControllerManager
 	StatusController      *controllers.StatusController
 	UndeliveredDetector   *controllers.UndeliveredDetector
+	StaleDeleteDetector   *controllers.StaleDeleteDetector
 
 	DB db.SessionFactory
 }
@@ -83,6 +93,11 @@ func (s ControllersServer) Start(ctx context.Context) {
 	if s.UndeliveredDetector != nil {
 		logger.Info("Starting undelivered resource detector")
 		go wait.JitterUntilWithContext(ctx, s.UndeliveredDetector.Run, 2*time.Minute, 0.25, true)
+	}
+
+	if s.StaleDeleteDetector != nil {
+		logger.Info("Starting stale delete event detector")
+		go wait.JitterUntilWithContext(ctx, s.StaleDeleteDetector.Run, 2*time.Minute, 0.25, true)
 	}
 
 	logger.Info("Status controller handling events")

--- a/pkg/config/event_server.go
+++ b/pkg/config/event_server.go
@@ -16,6 +16,7 @@ type EventServerConfig struct {
 	SubscriptionType             string                `json:"subscription_type"`
 	ConsistentHashConfig         *ConsistentHashConfig `json:"consistent_hash_config"`
 	UndeliveredResourceThreshold int                   `json:"undelivered_resource_threshold"`
+	StaleDeleteEventThreshold    int                   `json:"stale_delete_event_threshold"`
 }
 
 // ConsistentHashConfig contains the configuration for the consistent hashing algorithm.
@@ -31,6 +32,7 @@ func NewEventServerConfig() *EventServerConfig {
 		SubscriptionType:             "shared",
 		ConsistentHashConfig:         NewConsistentHashConfig(),
 		UndeliveredResourceThreshold: 600,
+		StaleDeleteEventThreshold:    3600,
 	}
 }
 
@@ -55,6 +57,7 @@ func NewConsistentHashConfig() *ConsistentHashConfig {
 func (c *EventServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.SubscriptionType, "subscription-type", c.SubscriptionType, "Sets the subscription type for resource status updates from message broker, Options: \"shared\" (only one instance receives resource status message, MQTT feature ensures exclusivity) or \"broadcast\" (all instances receive messages, hashed to determine processing instance)")
 	fs.IntVar(&c.UndeliveredResourceThreshold, "undelivered-resource-threshold", c.UndeliveredResourceThreshold, "Seconds a resource can have no status (NULL) before being re-published to the message broker. Set to 0 to disable. Default: 600 (10 minutes)")
+	fs.IntVar(&c.StaleDeleteEventThreshold, "stale-delete-event-threshold", c.StaleDeleteEventThreshold, "Seconds a resource can remain soft-deleted with an unreconciled delete event before that event is retired (the agent is assumed gone). Set to 0 to disable. Default: 3600 (1 hour)")
 	c.ConsistentHashConfig.AddFlags(fs)
 }
 

--- a/pkg/config/event_server_test.go
+++ b/pkg/config/event_server_test.go
@@ -24,6 +24,7 @@ func TestEventServerConfig(t *testing.T) {
 					Load:              1.25,
 				},
 				UndeliveredResourceThreshold: 600,
+				StaleDeleteEventThreshold:    3600,
 			},
 		},
 		{
@@ -39,6 +40,7 @@ func TestEventServerConfig(t *testing.T) {
 					Load:              1.25,
 				},
 				UndeliveredResourceThreshold: 600,
+				StaleDeleteEventThreshold:    3600,
 			},
 		},
 		{
@@ -57,6 +59,7 @@ func TestEventServerConfig(t *testing.T) {
 					Load:              1.5,
 				},
 				UndeliveredResourceThreshold: 600,
+				StaleDeleteEventThreshold:    3600,
 			},
 		},
 	}

--- a/pkg/controllers/stale_delete_detector.go
+++ b/pkg/controllers/stale_delete_detector.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift-online/maestro/pkg/dao"
+	"github.com/openshift-online/maestro/pkg/db"
+	"github.com/openshift-online/maestro/pkg/services"
+)
+
+var staleDeleteEventsReconciledTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Subsystem: specControllerMetricsSubsystem,
+		Name:      "stale_delete_events_reconciled_total",
+		Help:      "Total number of stuck delete events retired because their resource was soft-deleted with no agent to acknowledge the delete",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(staleDeleteEventsReconciledTotal)
+}
+
+// StaleDeleteDetector periodically retires delete events that can never be reconciled:
+// the resource has been soft-deleted (deletion requested) but its agent is gone and never
+// acknowledged the delete, so the resource is never hard-deleted. Because the resource is
+// read Unscoped, PredicateEvent keeps finding it and never takes the 404 mark-reconciled
+// fast path, so the single spec-event worker skips the event on every pass and the periodic
+// sync re-enqueues it forever, starving unrelated create/update events. Retiring these
+// events (marking them reconciled) breaks that loop.
+//
+// It runs as a singleton across all Maestro instances via an advisory lock and evaluates a
+// global view of the database, so it does not depend on any instance's local subscriber set.
+// The threshold ensures a delete is only retired once it has been pending long enough that a
+// still-connected agent (on any instance) would already have acknowledged it.
+type StaleDeleteDetector struct {
+	events      services.EventService
+	lockFactory db.LockFactory
+	threshold   time.Duration
+}
+
+func NewStaleDeleteDetector(
+	events services.EventService,
+	lockFactory db.LockFactory,
+	thresholdSeconds int,
+) *StaleDeleteDetector {
+	return &StaleDeleteDetector{
+		events:      events,
+		lockFactory: lockFactory,
+		threshold:   time.Duration(thresholdSeconds) * time.Second,
+	}
+}
+
+func (d *StaleDeleteDetector) Run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	lockOwnerID, acquired, err := d.lockFactory.NewNonBlockingLock(ctx, "maestro-stale-delete-check", db.Instances)
+	defer d.lockFactory.Unlock(ctx, lockOwnerID)
+	if err != nil {
+		logger.Error(err, "Error obtaining the stale delete event check lock")
+		return
+	}
+	if !acquired {
+		logger.V(4).Info("Another instance is checking stale delete events, skip")
+		return
+	}
+
+	count, svcErr := d.events.ReconcileStaleDeleteEvents(ctx, d.threshold)
+	if svcErr != nil {
+		logger.Error(svcErr, "Failed to reconcile stale delete events")
+		return
+	}
+
+	if count > 0 {
+		staleDeleteEventsReconciledTotal.Add(float64(count))
+		if count >= dao.StaleDeleteReconcileBatchSize {
+			logger.Info("Retired stale delete events, batch limit reached so more likely remain (draining on subsequent ticks)",
+				"count", count, "batchLimit", dao.StaleDeleteReconcileBatchSize, "threshold", d.threshold.String())
+		} else {
+			logger.Info("Retired stale delete events for soft-deleted resources with no agent",
+				"count", count, "threshold", d.threshold.String())
+		}
+	}
+}

--- a/pkg/dao/event.go
+++ b/pkg/dao/event.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm/clause"
 
@@ -21,6 +22,7 @@ type EventDao interface {
 	DeleteAllReconciledEvents(ctx context.Context) error
 	FindAllUnreconciledEvents(ctx context.Context) (api.EventList, error)
 	FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*float64, error)
+	ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error)
 }
 
 var _ EventDao = &sqlEventDao{}
@@ -102,6 +104,45 @@ func (d *sqlEventDao) FindAllUnreconciledEvents(ctx context.Context) (api.EventL
 		return nil, err
 	}
 	return events, nil
+}
+
+// StaleDeleteReconcileBatchSize bounds how many stale delete events a single
+// ReconcileStaleDeleteEvents call retires, so one periodic tick can never issue an
+// unbounded UPDATE (a backlog can reach hundreds of thousands of rows). Any remainder
+// is drained by subsequent ticks of the periodic detector.
+const StaleDeleteReconcileBatchSize = 10000
+
+// ReconcileStaleDeleteEvents marks as reconciled every unreconciled delete event whose
+// resource has been soft-deleted before the given cutoff. Such delete events are stuck:
+// the resource is soft-deleted (so PredicateEvent finds it via the Unscoped read and never
+// takes the 404 mark-reconciled fast path) but its agent is gone (never acknowledged the
+// delete), so the spec-event worker skips the event on every pass and the periodic sync
+// re-enqueues it forever. Retiring them stops that starvation loop. Each call retires at
+// most StaleDeleteReconcileBatchSize events to keep a single tick bounded, and returns the
+// number of events reconciled.
+func (d *sqlEventDao) ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error) {
+	staleResourceIDs := (*d.sessionFactory).New(ctx).
+		Unscoped().
+		Model(&api.Resource{}).
+		Select("id").
+		Where("deleted_at IS NOT NULL AND deleted_at < ?", cutoff)
+
+	staleEventIDs := (*d.sessionFactory).New(ctx).
+		Model(&api.Event{}).
+		Select("id").
+		Where("source = ? AND event_type = ? AND reconciled_date IS NULL", "Resources", api.DeleteEventType).
+		Where("source_id IN (?)", staleResourceIDs).
+		Limit(StaleDeleteReconcileBatchSize)
+
+	result := (*d.sessionFactory).New(ctx).
+		Model(&api.Event{}).
+		Where("id IN (?) AND reconciled_date IS NULL", staleEventIDs).
+		Update("reconciled_date", time.Now())
+	if result.Error != nil {
+		db.MarkForRollback(ctx, result.Error)
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
 }
 
 func (d *sqlEventDao) All(ctx context.Context) (api.EventList, error) {

--- a/pkg/dao/mocks/event.go
+++ b/pkg/dao/mocks/event.go
@@ -116,3 +116,18 @@ func (d *eventDaoMock) FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*f
 	}
 	return &oldest, nil
 }
+
+func (d *eventDaoMock) ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error) {
+	// TODO: the mock has no resource state, so it cannot evaluate the soft-deleted cutoff and
+	// ignores it, retiring every unreconciled Resources delete event. Tests that need to assert
+	// threshold/cutoff filtering must use the integration test (TestReconcileStaleDeleteEvents).
+	now := time.Now()
+	var count int64
+	for _, e := range d.events {
+		if e.ReconciledDate == nil && e.Source == "Resources" && e.EventType == api.DeleteEventType {
+			e.ReconciledDate = &now
+			count++
+		}
+	}
+	return count, nil
+}

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -50,7 +50,22 @@ func (d *resourceDaoMock) UpdateStatus(ctx context.Context, resource *api.Resour
 }
 
 func (d *resourceDaoMock) Delete(ctx context.Context, id string, unscoped bool) error {
-	return errors.NotImplemented("Resource").AsError()
+	for i, resource := range d.resources {
+		if resource.ID == id {
+			if unscoped {
+				// permanently remove the record
+				d.resources = append(d.resources[:i], d.resources[i+1:]...)
+				return nil
+			}
+			// soft delete: mark deleted_at, keeping the record retrievable via the
+			// Unscoped Get the real DAO performs.
+			if !resource.DeletedAt.Valid {
+				resource.DeletedAt = gorm.DeletedAt{Time: time.Now(), Valid: true}
+			}
+			return nil
+		}
+	}
+	return gorm.ErrRecordNotFound
 }
 
 func (d *resourceDaoMock) FindByIDs(ctx context.Context, ids []string) (api.ResourceList, error) {

--- a/pkg/services/event.go
+++ b/pkg/services/event.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"time"
 
 	"github.com/openshift-online/maestro/pkg/api"
 	"github.com/openshift-online/maestro/pkg/dao"
@@ -20,6 +21,7 @@ type EventService interface {
 	FindAllUnreconciledEvents(ctx context.Context) (api.EventList, *errors.ServiceError)
 	FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*float64, *errors.ServiceError)
 	DeleteAllReconciledEvents(ctx context.Context) *errors.ServiceError
+	ReconcileStaleDeleteEvents(ctx context.Context, threshold time.Duration) (int64, *errors.ServiceError)
 }
 
 func NewEventService(eventDao dao.EventDao) EventService {
@@ -102,4 +104,12 @@ func (s *sqlEventService) FindAgeOfOldestUnreconciledEvent(ctx context.Context) 
 		return nil, errors.GeneralError("Unable to get age of oldest unreconciled event: %s", err)
 	}
 	return ageInSeconds, nil
+}
+
+func (s *sqlEventService) ReconcileStaleDeleteEvents(ctx context.Context, threshold time.Duration) (int64, *errors.ServiceError) {
+	count, err := s.eventDao.ReconcileStaleDeleteEvents(ctx, time.Now().Add(-threshold))
+	if err != nil {
+		return 0, errors.GeneralError("Unable to reconcile stale delete events: %s", err)
+	}
+	return count, nil
 }

--- a/pkg/services/resource.go
+++ b/pkg/services/resource.go
@@ -273,6 +273,28 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 		return errors.DatabaseAdvisoryLock(err)
 	}
 
+	// MarkAsDeleting must be idempotent. A source can re-send a delete request for a
+	// resource whose deletion is already in flight (e.g. the agent is gone and never
+	// acknowledged the delete, so the resource stays soft-deleted). Without this guard
+	// every retry soft-deletes again (a no-op) and, crucially, appends another delete
+	// event to the queue. Those duplicate delete events accumulate without bound and can
+	// starve the single spec-event worker, blocking every unrelated create/update event.
+	// If the resource is already soft-deleted, a delete event has already been created and
+	// is pending delivery, so there is nothing more to do here.
+	existing, getErr := s.resourceDao.Get(ctx, id)
+	if getErr != nil {
+		svcErr := handleGetError("Resource", "id", id, getErr)
+		if svcErr.Is404() {
+			// the resource is already fully deleted, nothing to do
+			return nil
+		}
+		return svcErr
+	}
+	if existing.DeletedAt.Valid {
+		// deletion is already in flight, avoid enqueuing a duplicate delete event
+		return nil
+	}
+
 	if err := s.resourceDao.Delete(ctx, id, false); err != nil {
 		return handleDeleteError("Resource", errors.GeneralError("Unable to delete resource: %s", err))
 	}

--- a/pkg/services/resource_test.go
+++ b/pkg/services/resource_test.go
@@ -69,6 +69,47 @@ func TestCreateInvalidResource(t *testing.T) {
 	gm.Expect(len(invalidations)).To(gm.Equal(0))
 }
 
+// TestMarkAsDeletingIsIdempotent ensures a repeated delete request for a resource whose
+// deletion is already in flight does not append duplicate delete events. Sources retry
+// delete requests, and without this guard every retry enqueued another delete event,
+// letting them accumulate without bound and starve the single spec-event worker
+// (see AROSLSRE-1547).
+func TestMarkAsDeletingIsIdempotent(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	ctx := context.Background()
+	resourceDAO := mocks.NewResourceDao()
+	events := NewEventService(mocks.NewEventDao())
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
+
+	resource, svcErr := resourceService.Create(ctx, &api.Resource{
+		ConsumerName: Fukuisaurus,
+		Payload:      newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}}]}}"),
+	})
+	gm.Expect(svcErr).To(gm.BeNil())
+
+	countDeleteEvents := func() int {
+		unreconciled, err := events.FindAllUnreconciledEvents(ctx)
+		gm.Expect(err).To(gm.BeNil())
+		count := 0
+		for _, e := range unreconciled {
+			if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+				count++
+			}
+		}
+		return count
+	}
+
+	// first delete request soft-deletes the resource and enqueues a single delete event
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(countDeleteEvents()).To(gm.Equal(1))
+
+	// subsequent delete requests for the already-deleting resource are no-ops
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(countDeleteEvents()).To(gm.Equal(1))
+}
+
 func TestResourceList(t *testing.T) {
 	gm.RegisterTestingT(t)
 

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -535,6 +535,55 @@ func TestOnCreateDoesNotOrphanResourceMarkedAsDeleting(t *testing.T) {
 	Expect(h.EventServer.OnDelete(ctx, resource.ID)).To(Succeed())
 }
 
+// TestReconcileStaleDeleteEvents verifies the stale-delete finalizer: a resource that has
+// been soft-deleted longer than the threshold, whose agent never acknowledged the delete,
+// has its stuck (unreconciled) delete event retired so it stops starving the spec-event
+// worker (see AROSLSRE-1547).
+func TestReconcileStaleDeleteEvents(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx := context.Background()
+
+	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
+	Expect(err).NotTo(HaveOccurred())
+	deployName := fmt.Sprintf("nginx-%s", rand.String(5))
+	resource, err := h.CreateResource(uuid.NewString(), consumer.Name, deployName, "default", 1)
+	Expect(err).NotTo(HaveOccurred())
+
+	resourceService := h.Env().Services.Resources()
+	eventService := h.Env().Services.Events()
+
+	// mark the resource for deletion: soft-deletes it and enqueues a delete event that,
+	// with no agent to acknowledge it, would otherwise stay pending forever
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+
+	pendingDeletes := func() int {
+		unreconciled, svcErr := eventService.FindAllUnreconciledEvents(ctx)
+		Expect(svcErr).NotTo(HaveOccurred())
+		count := 0
+		for _, e := range unreconciled {
+			if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+				count++
+			}
+		}
+		return count
+	}
+	Expect(pendingDeletes()).To(Equal(1))
+
+	// with a threshold longer than the soft-delete age, nothing is retired yet
+	count, svcErr := eventService.ReconcileStaleDeleteEvents(ctx, time.Hour)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(count).To(Equal(int64(0)))
+	Expect(pendingDeletes()).To(Equal(1))
+
+	// a negative threshold puts the cutoff in the future, so the just soft-deleted
+	// resource qualifies and its stuck delete event is retired
+	count, svcErr = eventService.ReconcileStaleDeleteEvents(ctx, -time.Hour)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(count).To(Equal(int64(1)))
+	Expect(pendingDeletes()).To(Equal(0))
+}
+
 func updateWorkStatus(ctx context.Context, workClient workv1client.ManifestWorkInterface, work *workv1.ManifestWork, newStatus workv1.ManifestWorkStatus) error {
 	// update the work status
 	newWork := work.DeepCopy()


### PR DESCRIPTION
## Why

Prod `brazilsouth` had a 100% cluster-creation failure: every new HostedCluster's `spec.create` event was starved out of Maestro's spec-event controller by a backlog of orphaned `Delete` events (peaking ~171k/hr; 142k+ delete-skips and zero spec publishes over a ~3h window). The spec controller is a single FIFO worker with no fairness between event types, so once the Delete backlog dominates the queue, `create` events never reach the management cluster within the timeout — no ManifestWork, no control plane, readiness gate never clears.

Two independent bugs feed that backlog. This PR fixes both.

## Fix A — idempotent `MarkAsDeleting` (creation side)

Every retried source-side delete request appended a **new** `Delete` event, even when the resource was already soft-deleted or already gone. A stuck cluster retrying ~9/min produced hundreds of thousands of duplicate Deletes.

`MarkAsDeleting` now `Get`s the resource under the existing advisory lock and no-ops on `404` or an already-set `DeletedAt`, so one delete produces exactly one `Delete` event.

## Fix B — stale-delete finalizer (reconcile side)

In gRPC mode, `PredicateEvent` reads the resource `Unscoped`, so a soft-deleted resource is still found: the `404` mark-reconciled fast path is skipped and the event falls to a per-instance `Subscribers()` check that is `false` forever once the agent is gone. The 10h periodic sync then re-enqueues it indefinitely — a perpetual skip loop.

New `StaleDeleteDetector`: an advisory-locked **singleton** controller (modelled on `UndeliveredDetector`) with a **global DB view** that retires unreconciled `Delete` events whose resource has been soft-deleted longer than `--stale-delete-event-threshold` (default `3600s`, `0` disables). Singleton + global view + time threshold make it safe under multiple replicas — a local `Subscribers()` check can't tell "agent on another pod" from "agent gone", but "soft-deleted past the threshold with the delete still pending" can.

## Tests

- `TestMarkAsDeletingIsIdempotent` (unit) — a repeated delete request produces a single `Delete` event.
- `TestReconcileStaleDeleteEvents` (integration) — pending Deletes for resources soft-deleted past the cutoff are marked reconciled; fresh ones are left alone.

## Validation

- `go build ./...`, `go vet ./pkg/... ./cmd/...` clean.
- Unit test passes locally.

Jira: AROSLSRE-1547 (subtasks: AROSLSRE-1558 Fix A, AROSLSRE-1560 Fix B, AROSLSRE-1559 mitigation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for delete events that remain unresolved beyond a configurable age.
  * Added the `stale-delete-event-threshold` configuration/flag (default: 1 hour) to control cleanup timing.
  * Added a metric to track how many stale delete events were retired.

* **Bug Fixes**
  * Resource deletion is now idempotent, avoiding duplicate delete events when deletion is retried.
  * Already-deleted or missing resources no longer produce extra delete events.

* **Tests**
  * Added unit and integration coverage for stale-delete reconciliation and idempotent deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->