### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf
-	open-cluster-management.io/ocm v1.2.1-0.20260310135001-19a386c0609b
+	open-cluster-management.io/ocm v1.2.1
 	open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -111,8 +111,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/itchyny/gojq v0.12.18 // indirect
-	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,10 +278,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/itchyny/gojq v0.12.18 h1:gFGHyt/MLbG9n6dqnvlliiya2TaMMh6FFaR2b1H6Drc=
-github.com/itchyny/gojq v0.12.18/go.mod h1:4hPoZ/3lN9fDL1D+aK7DY1f39XZpY9+1Xpjz8atrEkg=
-github.com/itchyny/timefmt-go v0.1.7 h1:xyftit9Tbw+Dc/huSSPJaEmX1TVL8lw5vxjJLK4GMMA=
-github.com/itchyny/timefmt-go v0.1.7/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -796,8 +792,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf h1:SnLaZD2QHz+Ep2SfVKx9y5WIMmyLnQcEv/ySW8k/NXc=
 open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf/go.mod h1:ZpXs1bFTIIqKstMHdLO9IY0NFlbCvZgEtByvvNSmab0=
-open-cluster-management.io/ocm v1.2.1-0.20260310135001-19a386c0609b h1:ql7DNK7xoWYJTFhyUy/3KG64fjwj/TZBLCc9U1xyK9I=
-open-cluster-management.io/ocm v1.2.1-0.20260310135001-19a386c0609b/go.mod h1:NeXII90YZphP4T2jTPgt7uvrnQEnw5vcmmXmSQHVZms=
+open-cluster-management.io/ocm v1.2.1 h1:JC1mrIkaNjJ+AmLjiQ/sIhUE6Uzb3JVXFlFbaZF5+VY=
+open-cluster-management.io/ocm v1.2.1/go.mod h1:7jQB00gs+BxpvPTWvEWZ7x6RrkgqxLkVpqLpaCLmG8c=
 open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b h1:C919NhpIzPJO8iKzvej5gRhZV5S5rapa/YCznkjUPcU=
 open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b/go.mod h1:lDef+5BvifXww0S7cseux+Wi8melkH29bAf33OZ0ZVg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-5564 | open-cluster-management.io/ocm | High (cross-cluster privilege escalation via improper Kubernetes client certificate renewal validation) | v1.2.1 |

### CVEs noted (no fix available)
| ID | Module | Notes |
|----|--------|-------|
| GO-2026-5932 | golang.org/x/crypto (openpgp package) | Unmaintained/unsafe by design; no fixed version exists. Transitive/indirect dependency, not imported/called anywhere in this codebase. |

### Modules changed
- `open-cluster-management.io/ocm`: `v1.2.1-0.20260310135001-19a386c0609b` → `v1.2.1`
- `go mod tidy` dropped now-unused transitive deps (`github.com/itchyny/gojq`, `github.com/itchyny/timefmt-go`)

### Verification
- [x] govulncheck: clean (previously-affected CVE resolved; remaining GO-2026-5932 has no fix and isn't reachable from our code)
- [x] go build ./...: passing
- [x] golangci-lint run -D unused ./cmd/... ./pkg/...: no new findings (69 pre-existing issues identical before/after this change)
- [x] go test ./pkg/... ./cmd/...: passing (2 pre-existing failures due to missing local `secrets/db.password` file, unrelated to this change and present on `main` as well)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Open Cluster Management dependency to a stable release.
  * Removed unused indirect dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->