### PR TITLE
fix(server): stop re-publishing update spec for resources marked as deleting (AROSLSRE-1633)

### DIFF
--- a/cmd/maestro/server/grpc_broker.go
+++ b/cmd/maestro/server/grpc_broker.go
@@ -246,13 +246,28 @@ func (s *GRPCBroker) OnCreate(ctx context.Context, resourceID string) error {
 func (s *GRPCBroker) OnUpdate(ctx context.Context, resourceID string) error {
 	logger := klog.FromContext(ctx).WithValues("resourceID", resourceID)
 
-	evt, err := s.Get(ctx, resourceID, types.UpdateRequestAction)
-	if err != nil {
-		if kubeerrors.IsNotFound(err) {
+	resource, svcErr := s.resourceService.Get(ctx, resourceID)
+	if svcErr != nil {
+		if svcErr.Is404() {
 			logger.Info("skipping to publish update request for resource as it is not found")
 			return nil
 		}
-		return err
+		return kubeerrors.NewInternalError(svcErr)
+	}
+
+	if !resource.Meta.DeletedAt.Time.IsZero() {
+		// The resource is already marked as deleting. Publishing an update_request here would
+		// re-assert the resource spec to the agent and re-create a ManifestWork whose delete the
+		// agent has already processed, leaving the bundle non-empty so its delete never completes.
+		// Skip this update; the corresponding delete event will propagate the delete_request. This
+		// mirrors the OnCreate guard (ARO-28432).
+		logger.Info("skipping update for resource that is marked as deleting; the delete event will propagate the delete")
+		return nil
+	}
+
+	evt, err := EncodeResourceSpec(resource, types.UpdateRequestAction)
+	if err != nil {
+		return kubeerrors.NewInternalError(err)
 	}
 	return s.eventServer.HandleEvent(ctx, evt)
 }

--- a/cmd/maestro/server/grpc_broker_test.go
+++ b/cmd/maestro/server/grpc_broker_test.go
@@ -174,6 +174,55 @@ func TestGRPCBrokerOnUpdateSkipsWhenResourceNotFound(t *testing.T) {
 	Expect(fakeEventServer.handledEvents).To(BeEmpty())
 }
 
+// TestGRPCBrokerOnUpdateSkipsResourceMarkedAsDeleting verifies that OnUpdate does not publish an
+// update_request to the agent for a resource that is already marked as deleting. Re-publishing the
+// spec here re-creates a ManifestWork whose delete the agent has already processed, which keeps the
+// bundle non-empty so its delete never completes (observed in stg/int). Mirrors the OnCreate guard.
+func TestGRPCBrokerOnUpdateSkipsResourceMarkedAsDeleting(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta: api.Meta{
+			ID:        "res-4",
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resource: resource}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnUpdate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(BeEmpty(), "OnUpdate must not publish update_request for a resource marked as deleting")
+}
+
+// TestGRPCBrokerOnUpdatePublishesForNormalResource verifies OnUpdate publishes an update_request
+// for a resource that is not marked as deleting.
+func TestGRPCBrokerOnUpdatePublishesForNormalResource(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta:         api.Meta{ID: "res-5"},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resource: resource}
+	fakeEventServer := &fakeAgentEventServer{}
+	broker := &GRPCBroker{
+		resourceService: fakeSvc,
+		eventServer:     fakeEventServer,
+	}
+
+	err := broker.OnUpdate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(fakeEventServer.handledEvents).To(HaveLen(1))
+}
+
 // TestGRPCBrokerOnDeletePublishesForExistingResource verifies OnDelete publishes a
 // delete_request for a resource that still exists and is marked as deleting.
 func TestGRPCBrokerOnDeletePublishesForExistingResource(t *testing.T) {

--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -116,6 +116,16 @@ func (s *SourceClientImpl) OnUpdate(ctx context.Context, id string) error {
 		return err
 	}
 
+	if !resource.Meta.DeletedAt.Time.IsZero() {
+		// The resource is already marked as deleting. Publishing an update_request here would
+		// re-assert the resource spec to the agent and re-create a ManifestWork whose delete the
+		// agent has already processed, leaving the bundle non-empty so its delete never completes.
+		// Skip this update; the corresponding delete event will publish the delete_request. This
+		// mirrors the OnCreate guard (ARO-28432).
+		logger.Info("skipping update for resource that is marked as deleting; the delete event will propagate the delete")
+		return nil
+	}
+
 	logger.Info("Publishing resource for db row update")
 	eventType := cetypes.CloudEventsType{
 		CloudEventsDataType: s.Codec.EventDataType(),

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -175,19 +175,16 @@ func TestOnUpdateSkipsPublishForResourceMarkedAsDeleting(t *testing.T) {
 		},
 	}
 	mockSvc := &getDeleteMockResourceService{resource: resource}
-	transport := &mockTransport{}
 	client := &SourceClientImpl{
 		Codec:           NewCodec("test-source"),
 		ResourceService: mockSvc,
 		sourceID:        "test-source",
-		transport:       transport,
 	}
 
 	// CloudEventSourceClient is intentionally nil: the guard must return before any publish, so
-	// reaching the publish path would panic and fail the test.
+	// reaching the publish path would nil-panic and fail the test. That is what enforces the guard.
 	err := client.OnUpdate(context.Background(), resource.ID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(transport.sentEvents).To(BeEmpty(), "OnUpdate must not publish update_request for a resource marked as deleting")
+	Expect(err).NotTo(HaveOccurred(), "OnUpdate must skip (not publish) for a resource marked as deleting")
 }
 
 // TestOnUpdateSkipsWhenResourceNotFound verifies OnUpdate is a no-op when the resource has already
@@ -196,17 +193,14 @@ func TestOnUpdateSkipsWhenResourceNotFound(t *testing.T) {
 	RegisterTestingT(t)
 
 	mockSvc := &getDeleteMockResourceService{getErr: errors.NotFound("resource not found")}
-	transport := &mockTransport{}
 	client := &SourceClientImpl{
 		Codec:           NewCodec("test-source"),
 		ResourceService: mockSvc,
 		sourceID:        "test-source",
-		transport:       transport,
 	}
 
 	err := client.OnUpdate(context.Background(), uuid.New().String())
 	Expect(err).NotTo(HaveOccurred())
-	Expect(transport.sentEvents).To(BeEmpty())
 }
 
 func decodeHashList(evt cloudevents.Event) *cepayload.ResourceStatusHashList {

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -161,6 +161,54 @@ func TestOnCreateSkipsWhenResourceNotFound(t *testing.T) {
 	Expect(mockSvc.deleteCalled).To(BeFalse())
 }
 
+// TestOnUpdateSkipsPublishForResourceMarkedAsDeleting verifies that OnUpdate does NOT publish an
+// update_request for a resource that is already marked as deleting (DeletedAt set). Re-publishing
+// the spec re-creates a ManifestWork whose delete the agent has already processed, keeping the
+// bundle non-empty so its delete never completes (observed in stg/int). Mirrors the OnCreate guard.
+func TestOnUpdateSkipsPublishForResourceMarkedAsDeleting(t *testing.T) {
+	RegisterTestingT(t)
+
+	resource := &api.Resource{
+		Meta: api.Meta{
+			ID:        uuid.New().String(),
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+	}
+	mockSvc := &getDeleteMockResourceService{resource: resource}
+	transport := &mockTransport{}
+	client := &SourceClientImpl{
+		Codec:           NewCodec("test-source"),
+		ResourceService: mockSvc,
+		sourceID:        "test-source",
+		transport:       transport,
+	}
+
+	// CloudEventSourceClient is intentionally nil: the guard must return before any publish, so
+	// reaching the publish path would panic and fail the test.
+	err := client.OnUpdate(context.Background(), resource.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(transport.sentEvents).To(BeEmpty(), "OnUpdate must not publish update_request for a resource marked as deleting")
+}
+
+// TestOnUpdateSkipsWhenResourceNotFound verifies OnUpdate is a no-op when the resource has already
+// been hard-deleted (404).
+func TestOnUpdateSkipsWhenResourceNotFound(t *testing.T) {
+	RegisterTestingT(t)
+
+	mockSvc := &getDeleteMockResourceService{getErr: errors.NotFound("resource not found")}
+	transport := &mockTransport{}
+	client := &SourceClientImpl{
+		Codec:           NewCodec("test-source"),
+		ResourceService: mockSvc,
+		sourceID:        "test-source",
+		transport:       transport,
+	}
+
+	err := client.OnUpdate(context.Background(), uuid.New().String())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(transport.sentEvents).To(BeEmpty())
+}
+
 func decodeHashList(evt cloudevents.Event) *cepayload.ResourceStatusHashList {
 	list := &cepayload.ResourceStatusHashList{}
 	Expect(json.Unmarshal(evt.Data(), list)).To(Succeed())


### PR DESCRIPTION
## Description

`OnCreate` already skips publishing a spec when the resource is marked as deleting (`DeletedAt` set), added in cb6f04e for [ARO-28432](https://redhat.atlassian.net/browse/ARO-28432). `OnUpdate` never got the same guard.

When an update event fires for a soft-deleted resource (it is still returned by the spec resync / `List` path, which re-attaches the deletion timestamp), `OnUpdate` re-publishes the spec as an `update_request`. The agent then re-creates the ManifestWork whose delete it already processed, the outer bundle never empties, and the single spec worker re-emits `delete_request` for hours. We saw this break node-pool E2E tests in both stg and int, where an inner ManifestWork was deleted and then re-applied dozens to hundreds of times.

This adds the same `DeletedAt` guard to `OnUpdate` in both transports, `SourceClientImpl` (MQTT path) and `GRPCBroker` (gRPC path), so an update spec is not re-published for a resource marked as deleting. The delete event alone propagates the delete.

Jira: [AROSLSRE-1633](https://redhat.atlassian.net/browse/AROSLSRE-1633)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

Added unit tests mirroring the existing `OnCreate` coverage:

- `pkg/client/cloudevents` (MQTT / `SourceClientImpl.OnUpdate`): skip-when-deleting and skip-when-404. This mirrors the existing `OnCreate` tests, which likewise cover the skip paths; the normal publish path goes through the generic `CloudEventSourceClient` and is exercised by the gRPC broker test below and the e2e jobs.
- `cmd/maestro/server` (gRPC / `GRPCBroker.OnUpdate`): skip-when-deleting, skip-when-404, and publish-when-normal.

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented update events from being sent for resources already marked for deletion.
  * Prevented update events from being sent when the target resource no longer exists.
  * Improved deletion handling to avoid interfering with the resource removal process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->