### PR TITLE
ARO-28817: fix(server): exclude deleting resources from spec resync response

### DIFF
--- a/cmd/maestro/server/grpc_broker.go
+++ b/cmd/maestro/server/grpc_broker.go
@@ -55,6 +55,14 @@ func (s *GRPCBrokerService) List(ctx context.Context, listOpts types.ListOptions
 
 	evts := []*ce.Event{}
 	for _, res := range resources {
+		if !res.Meta.DeletedAt.Time.IsZero() {
+			// Skip resources marked as deleting. Including them in a spec resync causes the
+			// agent to re-apply a ManifestWork that it already deleted, creating an infinite
+			// delete-then-recreate loop. The sdk-go source client handles the missing resource
+			// correctly: it detects that the resource exists on the agent but not in the
+			// server's response, and sends a delete_request to the agent.
+			continue
+		}
 		evt, err := EncodeResourceSpec(res, types.ResyncResponseAction)
 		if err != nil {
 			return nil, kubeerrors.NewInternalError(err)

--- a/cmd/maestro/server/grpc_broker_test.go
+++ b/cmd/maestro/server/grpc_broker_test.go
@@ -63,8 +63,9 @@ func (f *fakeAgentEventServer) Subscribers() sets.Set[string] {
 // GRPCBroker's OnCreate/OnUpdate/OnDelete handlers in isolation.
 type fakeResourceService struct {
 	services.ResourceService
-	resource *api.Resource
-	getErr   *errors.ServiceError
+	resource  *api.Resource
+	resources []*api.Resource
+	getErr    *errors.ServiceError
 }
 
 func (m *fakeResourceService) Get(_ context.Context, _ string) (*api.Resource, *errors.ServiceError) {
@@ -72,6 +73,10 @@ func (m *fakeResourceService) Get(_ context.Context, _ string) (*api.Resource, *
 		return nil, m.getErr
 	}
 	return m.resource, nil
+}
+
+func (m *fakeResourceService) List(_ context.Context, _ types.ListOptions) ([]*api.Resource, error) {
+	return m.resources, nil
 }
 
 // TestGRPCBrokerOnCreateSkipsResourceMarkedAsDeleting verifies that OnCreate does not publish a
@@ -246,4 +251,57 @@ func TestGRPCBrokerOnDeletePublishesForExistingResource(t *testing.T) {
 	err := broker.OnDelete(context.Background(), resource.ID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fakeEventServer.handledEvents).To(HaveLen(1))
+}
+
+// TestGRPCBrokerServiceListExcludesDeletingResources verifies that List does not return
+// CloudEvents for resources marked as deleting. Including them causes the agent to re-apply
+// a ManifestWork that it already deleted, creating an infinite delete-then-recreate loop.
+// The sdk-go source client handles the missing resource correctly during resync: it detects
+// that the resource exists on the agent but not in the server's response, and sends a
+// delete_request to the agent.
+func TestGRPCBrokerServiceListExcludesDeletingResources(t *testing.T) {
+	RegisterTestingT(t)
+
+	live := &api.Resource{
+		Meta:         api.Meta{ID: "live-1"},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	deleting := &api.Resource{
+		Meta: api.Meta{
+			ID:        "deleting-1",
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resources: []*api.Resource{live, deleting}}
+	svc := &GRPCBrokerService{resourceService: fakeSvc}
+
+	evts, err := svc.List(context.Background(), types.ListOptions{ClusterName: "cluster1"})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(evts).To(HaveLen(1), "List must exclude resources marked as deleting")
+}
+
+// TestGRPCBrokerServiceListIncludesLiveResources verifies that List returns
+// CloudEvents for live (non-deleting) resources.
+func TestGRPCBrokerServiceListIncludesLiveResources(t *testing.T) {
+	RegisterTestingT(t)
+
+	r1 := &api.Resource{
+		Meta:         api.Meta{ID: "res-1"},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	r2 := &api.Resource{
+		Meta:         api.Meta{ID: "res-2"},
+		ConsumerName: "cluster1",
+		Payload:      testPayload(t),
+	}
+	fakeSvc := &fakeResourceService{resources: []*api.Resource{r1, r2}}
+	svc := &GRPCBrokerService{resourceService: fakeSvc}
+
+	evts, err := svc.List(context.Background(), types.ListOptions{ClusterName: "cluster1"})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(evts).To(HaveLen(2), "List must include all live resources")
 }

--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -212,6 +212,10 @@ func (s *SourceClientImpl) resyncConsumer(ctx context.Context, consumer string) 
 
 	hashes := make([]cepayload.ResourceStatusHash, 0, len(objs))
 	for _, obj := range objs {
+		if !obj.GetDeletionTimestamp().IsZero() {
+			// Skip resources marked as deleting — same rationale as GRPCBrokerService.List.
+			continue
+		}
 		statusHash, err := ResourceStatusHashGetter(obj)
 		if err != nil {
 			return err

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -327,3 +327,29 @@ func TestResyncConsumerEventStructure(t *testing.T) {
 	Expect(list2.Hashes).To(HaveLen(1))
 	Expect(list2.Hashes[0].StatusHash).NotTo(BeEmpty())
 }
+
+// TestResyncConsumerExcludesDeletingResources verifies that resyncConsumer does not include
+// resources marked as deleting in the status hash list sent to the agent. Including them
+// causes the agent to re-apply a ManifestWork that it already deleted.
+func TestResyncConsumerExcludesDeletingResources(t *testing.T) {
+	RegisterTestingT(t)
+
+	live := &api.Resource{
+		Meta: api.Meta{ID: uuid.New().String()},
+	}
+	deleting := &api.Resource{
+		Meta: api.Meta{
+			ID:        uuid.New().String(),
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		},
+	}
+	transport := &mockTransport{}
+	client := newTestSourceClient(transport, []*api.Resource{live, deleting})
+
+	Expect(client.resyncConsumer(context.Background(), "consumer-1")).To(Succeed())
+	Expect(transport.sentEvents).To(HaveLen(1))
+
+	list := decodeHashList(transport.sentEvents[0])
+	Expect(list.Hashes).To(HaveLen(1), "resyncConsumer must exclude resources marked as deleting")
+	Expect(list.Hashes[0].ResourceID).To(Equal(live.ID))
+}

--- a/pkg/dao/mocks/resource.go
+++ b/pkg/dao/mocks/resource.go
@@ -75,7 +75,7 @@ func (d *resourceDaoMock) FindByIDs(ctx context.Context, ids []string) (api.Reso
 func (d *resourceDaoMock) FindByConsumerName(ctx context.Context, consumerID string) (api.ResourceList, error) {
 	var resources api.ResourceList
 	for _, resource := range d.resources {
-		if resource.ConsumerName == consumerID {
+		if resource.ConsumerName == consumerID && resource.Meta.DeletedAt.Time.IsZero() {
 			resources = append(resources, resource)
 		}
 	}

--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -115,7 +115,7 @@ func (d *sqlResourceDao) FindBySource(ctx context.Context, source string) (api.R
 func (d *sqlResourceDao) FindByConsumerName(ctx context.Context, consumerName string) (api.ResourceList, error) {
 	g2 := (*d.sessionFactory).New(ctx)
 	resources := api.ResourceList{}
-	if err := g2.Unscoped().Where("consumer_name = ?", consumerName).Find(&resources).Error; err != nil {
+	if err := g2.Unscoped().Where("consumer_name = ? AND deleted_at IS NULL", consumerName).Find(&resources).Error; err != nil {
 		return nil, err
 	}
 	return resources, nil


### PR DESCRIPTION
GRPCBrokerService.List and SourceClientImpl.resyncConsumer return soft-deleted resources to the agent during spec resync because FindByConsumerName uses Unscoped(). The agent treats the resync response as "apply these specs" and re-creates ManifestWorks that it already deleted, producing an infinite delete-then-recreate loop.

This is the remaining exposure after ARO-28432 (OnCreate guard), AROSLSRE-1547 (MarkAsDeleting idempotency), and AROSLSRE-1633 (OnUpdate guard), which guard event-driven paths but not the resync path. Filtering is safe because the sdk-go source client's resync handler detects resources present on the agent but absent from the server's response and sends a delete_request for them.

Jira: ARO-28817

## Description

<!-- Briefly describe the change and its motivation. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resynchronization responses and events now exclude resources marked for deletion.
  - Resource listings return only active resources.
  - Live resources continue to be returned as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->