### PR TITLE
fix: add logging to MarkAsDeleting idempotency early-returns

### DIFF
--- a/pkg/services/resource.go
+++ b/pkg/services/resource.go
@@ -268,6 +268,8 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 		return errors.DatabaseAdvisoryLock(err)
 	}
 
+	logger := klog.FromContext(ctx).WithValues("resourceID", id)
+
 	// MarkAsDeleting must be idempotent. A source can re-send a delete request for a
 	// resource whose deletion is already in flight (e.g. the agent is gone and never
 	// acknowledged the delete, so the resource stays soft-deleted). Without this guard
@@ -286,7 +288,7 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 	if getErr != nil {
 		svcErr := handleGetError("Resource", "id", id, getErr)
 		if svcErr.Is404() {
-			// the resource is already fully deleted, nothing to do
+			logger.Info("skipping delete for resource as it is already fully deleted")
 			return nil
 		}
 		return svcErr


### PR DESCRIPTION
## Summary

- Adds `klog.Info` log lines to the two silent early-return paths in `MarkAsDeleting` (`pkg/services/resource.go`)
- When a resource is already fully deleted (404): logs `"skipping delete for resource as it is already fully deleted"`
- When deletion is already in flight (`DeletedAt.Valid`): logs `"skipping delete for resource as deletion is already in flight"`

Previously these paths returned `nil` with zero logging, making it appear Maestro was ignoring repeated delete requests from CS.

Ref: [HYPERFLEET-1496](https://redhat.atlassian.net/browse/HYPERFLEET-1496)

## Test plan

- [ ] Verify `go build ./pkg/services/` compiles cleanly
- [ ] Verify unit tests pass (`make test`)
- [ ] Confirm log messages appear in server output when duplicate delete requests are received

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for deleted resources.
  * Delete events can now be republished after a configured interval when appropriate.
  * Retries safely handle disabled republishing, lookup issues, and recently published events.
  * Fully deleted resources are skipped without causing failures.
  * Preserved idempotent deletion behavior.

* **Metrics**
  * Improved resource metrics privacy by removing resource identifiers from metric labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->