### PR TITLE
fix: republish delete events for resources stuck deleting (HYPERFLEET-1497)

### DIFF
--- a/cmd/maestro/environments/service_types.go
+++ b/cmd/maestro/environments/service_types.go
@@ -15,6 +15,7 @@ func NewResourceServiceLocator(env *Env) ResourceServiceLocator {
 			dao.NewResourceDao(&env.Database.SessionFactory),
 			env.Services.Events(),
 			env.Services.Generic(),
+			env.Config.EventServer.DeleteEventRepublishInterval,
 		)
 	}
 }

--- a/pkg/config/event_server.go
+++ b/pkg/config/event_server.go
@@ -17,6 +17,7 @@ type EventServerConfig struct {
 	ConsistentHashConfig         *ConsistentHashConfig `json:"consistent_hash_config"`
 	UndeliveredResourceThreshold int                   `json:"undelivered_resource_threshold"`
 	StaleDeleteEventThreshold    int                   `json:"stale_delete_event_threshold"`
+	DeleteEventRepublishInterval int                   `json:"delete_event_republish_interval"`
 }
 
 // ConsistentHashConfig contains the configuration for the consistent hashing algorithm.
@@ -33,6 +34,7 @@ func NewEventServerConfig() *EventServerConfig {
 		ConsistentHashConfig:         NewConsistentHashConfig(),
 		UndeliveredResourceThreshold: 600,
 		StaleDeleteEventThreshold:    3600,
+		DeleteEventRepublishInterval: 60,
 	}
 }
 
@@ -58,6 +60,7 @@ func (c *EventServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.SubscriptionType, "subscription-type", c.SubscriptionType, "Sets the subscription type for resource status updates from message broker, Options: \"shared\" (only one instance receives resource status message, MQTT feature ensures exclusivity) or \"broadcast\" (all instances receive messages, hashed to determine processing instance)")
 	fs.IntVar(&c.UndeliveredResourceThreshold, "undelivered-resource-threshold", c.UndeliveredResourceThreshold, "Seconds a resource can have no status (NULL) before being re-published to the message broker. Set to 0 to disable. Default: 600 (10 minutes)")
 	fs.IntVar(&c.StaleDeleteEventThreshold, "stale-delete-event-threshold", c.StaleDeleteEventThreshold, "Seconds a resource can remain soft-deleted with an unreconciled delete event before that event is retired (the agent is assumed gone). Set to 0 to disable. Default: 3600 (1 hour)")
+	fs.IntVar(&c.DeleteEventRepublishInterval, "delete-event-republish-interval", c.DeleteEventRepublishInterval, "Seconds before a delete event is re-published for a resource that remains soft-deleted when another delete request arrives, healing agents that lost the deletion state. Raising it trades healing latency for fewer queued events per stuck resource. Set to 0 to disable republishing. Default: 60 (1 minute)")
 	c.ConsistentHashConfig.AddFlags(fs)
 }
 

--- a/pkg/config/event_server_test.go
+++ b/pkg/config/event_server_test.go
@@ -25,6 +25,7 @@ func TestEventServerConfig(t *testing.T) {
 				},
 				UndeliveredResourceThreshold: 600,
 				StaleDeleteEventThreshold:    3600,
+				DeleteEventRepublishInterval: 60,
 			},
 		},
 		{
@@ -41,6 +42,7 @@ func TestEventServerConfig(t *testing.T) {
 				},
 				UndeliveredResourceThreshold: 600,
 				StaleDeleteEventThreshold:    3600,
+				DeleteEventRepublishInterval: 60,
 			},
 		},
 		{
@@ -60,6 +62,7 @@ func TestEventServerConfig(t *testing.T) {
 				},
 				UndeliveredResourceThreshold: 600,
 				StaleDeleteEventThreshold:    3600,
+				DeleteEventRepublishInterval: 60,
 			},
 		},
 	}

--- a/pkg/controllers/undelivered_detector_test.go
+++ b/pkg/controllers/undelivered_detector_test.go
@@ -19,7 +19,7 @@ func TestUndeliveredDetector(t *testing.T) {
 	ctx := context.Background()
 	resourcesDao := mocks.NewResourceDao()
 	eventsDao := mocks.NewEventDao()
-	resourceService := services.NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourcesDao, services.NewEventService(eventsDao), nil)
+	resourceService := services.NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourcesDao, services.NewEventService(eventsDao), nil, 60)
 	eventService := services.NewEventService(eventsDao)
 
 	threshold := 5 * time.Minute

--- a/pkg/dao/event.go
+++ b/pkg/dao/event.go
@@ -2,9 +2,11 @@ package dao
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
 	"github.com/openshift-online/maestro/pkg/api"
@@ -23,6 +25,7 @@ type EventDao interface {
 	FindAllUnreconciledEvents(ctx context.Context) (api.EventList, error)
 	FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*float64, error)
 	ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error)
+	FindLatestDeleteEvent(ctx context.Context, sourceID string) (*api.Event, error)
 }
 
 var _ EventDao = &sqlEventDao{}
@@ -120,6 +123,11 @@ const StaleDeleteReconcileBatchSize = 10000
 // re-enqueues it forever. Retiring them stops that starvation loop. Each call retires at
 // most StaleDeleteReconcileBatchSize events to keep a single tick bounded, and returns the
 // number of events reconciled.
+//
+// Only events that are themselves older than the cutoff are retired: a freshly
+// re-published delete event (see MarkAsDeleting's healing republish) for a long
+// soft-deleted resource must get a full threshold's worth of delivery attempts before
+// it is considered stale.
 func (d *sqlEventDao) ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error) {
 	staleResourceIDs := (*d.sessionFactory).New(ctx).
 		Unscoped().
@@ -131,6 +139,7 @@ func (d *sqlEventDao) ReconcileStaleDeleteEvents(ctx context.Context, cutoff tim
 		Model(&api.Event{}).
 		Select("id").
 		Where("source = ? AND event_type = ? AND reconciled_date IS NULL", "Resources", api.DeleteEventType).
+		Where("created_at < ?", cutoff).
 		Where("source_id IN (?)", staleResourceIDs).
 		Limit(StaleDeleteReconcileBatchSize)
 
@@ -143,6 +152,24 @@ func (d *sqlEventDao) ReconcileStaleDeleteEvents(ctx context.Context, cutoff tim
 		return 0, result.Error
 	}
 	return result.RowsAffected, nil
+}
+
+// FindLatestDeleteEvent returns the most recently created delete event for the given
+// resource, or (nil, nil) if the resource has no delete events. It is used to throttle
+// the re-publishing of delete events for resources stuck soft-deleted.
+func (d *sqlEventDao) FindLatestDeleteEvent(ctx context.Context, sourceID string) (*api.Event, error) {
+	g2 := (*d.sessionFactory).New(ctx)
+	var event api.Event
+	err := g2.Where("source = ? AND source_id = ? AND event_type = ?", "Resources", sourceID, api.DeleteEventType).
+		Order("created_at DESC").
+		First(&event).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &event, nil
 }
 
 func (d *sqlEventDao) All(ctx context.Context) (api.EventList, error) {

--- a/pkg/dao/mocks/event.go
+++ b/pkg/dao/mocks/event.go
@@ -30,6 +30,11 @@ func (d *eventDaoMock) Get(ctx context.Context, id string) (*api.Event, error) {
 }
 
 func (d *eventDaoMock) Create(ctx context.Context, event *api.Event) (*api.Event, error) {
+	// mirror gorm's autoCreateTime so age-based logic (e.g. the delete-event republish
+	// throttle) sees a realistic creation time instead of the zero value
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now()
+	}
 	d.events = append(d.events, event)
 	return event, nil
 }
@@ -118,16 +123,31 @@ func (d *eventDaoMock) FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*f
 }
 
 func (d *eventDaoMock) ReconcileStaleDeleteEvents(ctx context.Context, cutoff time.Time) (int64, error) {
-	// TODO: the mock has no resource state, so it cannot evaluate the soft-deleted cutoff and
-	// ignores it, retiring every unreconciled Resources delete event. Tests that need to assert
-	// threshold/cutoff filtering must use the integration test (TestReconcileStaleDeleteEvents).
+	// TODO: the mock has no resource state, so it cannot evaluate the resource soft-deleted
+	// cutoff and ignores that half of the predicate. The event-age half is applied. Tests
+	// that need to assert resource-cutoff filtering must use the integration test
+	// (TestReconcileStaleDeleteEvents).
 	now := time.Now()
 	var count int64
 	for _, e := range d.events {
-		if e.ReconciledDate == nil && e.Source == "Resources" && e.EventType == api.DeleteEventType {
+		if e.ReconciledDate == nil && e.Source == "Resources" && e.EventType == api.DeleteEventType &&
+			e.CreatedAt.Before(cutoff) {
 			e.ReconciledDate = &now
 			count++
 		}
 	}
 	return count, nil
+}
+
+func (d *eventDaoMock) FindLatestDeleteEvent(ctx context.Context, sourceID string) (*api.Event, error) {
+	var latest *api.Event
+	for _, e := range d.events {
+		if e.Source != "Resources" || e.SourceID != sourceID || e.EventType != api.DeleteEventType {
+			continue
+		}
+		if latest == nil || e.CreatedAt.After(latest.CreatedAt) {
+			latest = e
+		}
+	}
+	return latest, nil
 }

--- a/pkg/services/event.go
+++ b/pkg/services/event.go
@@ -22,6 +22,7 @@ type EventService interface {
 	FindAgeOfOldestUnreconciledEvent(ctx context.Context) (*float64, *errors.ServiceError)
 	DeleteAllReconciledEvents(ctx context.Context) *errors.ServiceError
 	ReconcileStaleDeleteEvents(ctx context.Context, threshold time.Duration) (int64, *errors.ServiceError)
+	FindLatestDeleteEvent(ctx context.Context, sourceID string) (*api.Event, *errors.ServiceError)
 }
 
 func NewEventService(eventDao dao.EventDao) EventService {
@@ -104,6 +105,16 @@ func (s *sqlEventService) FindAgeOfOldestUnreconciledEvent(ctx context.Context) 
 		return nil, errors.GeneralError("Unable to get age of oldest unreconciled event: %s", err)
 	}
 	return ageInSeconds, nil
+}
+
+// FindLatestDeleteEvent returns the most recently created delete event for the given
+// resource, or (nil, nil) if the resource has no delete events.
+func (s *sqlEventService) FindLatestDeleteEvent(ctx context.Context, sourceID string) (*api.Event, *errors.ServiceError) {
+	event, err := s.eventDao.FindLatestDeleteEvent(ctx, sourceID)
+	if err != nil {
+		return nil, errors.GeneralError("Unable to get latest delete event for resource %s: %s", sourceID, err)
+	}
+	return event, nil
 }
 
 func (s *sqlEventService) ReconcileStaleDeleteEvents(ctx context.Context, threshold time.Duration) (int64, *errors.ServiceError) {

--- a/pkg/services/resource.go
+++ b/pkg/services/resource.go
@@ -38,12 +38,13 @@ type ResourceService interface {
 	ListWithArgs(ctx context.Context, username string, args *ListArguments, resources *[]api.Resource) (*api.PagingMeta, *errors.ServiceError)
 }
 
-func NewResourceService(lockFactory db.LockFactory, resourceDao dao.ResourceDao, events EventService, generic GenericService) ResourceService {
+func NewResourceService(lockFactory db.LockFactory, resourceDao dao.ResourceDao, events EventService, generic GenericService, deleteEventRepublishIntervalSeconds int) ResourceService {
 	return &sqlResourceService{
-		lockFactory: lockFactory,
-		resourceDao: resourceDao,
-		events:      events,
-		generic:     generic,
+		lockFactory:                  lockFactory,
+		resourceDao:                  resourceDao,
+		events:                       events,
+		generic:                      generic,
+		deleteEventRepublishInterval: time.Duration(deleteEventRepublishIntervalSeconds) * time.Second,
 	}
 }
 
@@ -54,6 +55,10 @@ type sqlResourceService struct {
 	resourceDao dao.ResourceDao
 	events      EventService
 	generic     GenericService
+	// deleteEventRepublishInterval throttles how often a delete event is re-published for
+	// a resource that remains soft-deleted when another delete request arrives; 0 disables
+	// republishing entirely.
+	deleteEventRepublishInterval time.Duration
 }
 
 func (s *sqlResourceService) Get(ctx context.Context, id string) (*api.Resource, *errors.ServiceError) {
@@ -279,8 +284,14 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 	// every retry soft-deletes again (a no-op) and, crucially, appends another delete
 	// event to the queue. Those duplicate delete events accumulate without bound and can
 	// starve the single spec-event worker, blocking every unrelated create/update event.
-	// If the resource is already soft-deleted, a delete event has already been created and
-	// is pending delivery, so there is nothing more to do here.
+	//
+	// However, a resource stuck soft-deleted can also mean the agent lost the deletion
+	// state (e.g. its in-memory store dropped the DeletionTimestamp) and will never
+	// converge without the delete event being re-delivered. To heal that, a retried
+	// delete re-publishes the delete event, throttled to at most one new event per
+	// deleteEventRepublishInterval per resource, so retries can never accumulate events
+	// without bound. The whole check-then-create runs under the advisory lock above, so
+	// it is serialized across all maestro instances.
 	existing, getErr := s.resourceDao.Get(ctx, id)
 	if getErr != nil {
 		svcErr := handleGetError("Resource", "id", id, getErr)
@@ -291,8 +302,9 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 		return svcErr
 	}
 	if existing.DeletedAt.Valid {
-		// deletion is already in flight, avoid enqueuing a duplicate delete event
-		return nil
+		// deletion is already in flight; re-publish the delete event if the latest one
+		// is older than the republish interval, otherwise do nothing
+		return s.republishDeleteEvent(ctx, id)
 	}
 
 	if err := s.resourceDao.Delete(ctx, id, false); err != nil {
@@ -306,6 +318,49 @@ func (s *sqlResourceService) MarkAsDeleting(ctx context.Context, id string) *err
 	}); err != nil {
 		return handleDeleteError("Resource", err)
 	}
+
+	return nil
+}
+
+// republishDeleteEvent re-enqueues a delete event for a resource that is stuck
+// soft-deleted, at most once per deleteEventRepublishInterval per resource. A
+// re-delivered delete event re-stamps the deletion state on the agent (healing e.g. an
+// agent whose in-memory store lost the DeletionTimestamp and so never acknowledges the
+// delete), while the throttle keeps retried deletes from accumulating events without
+// bound (the AROSLSRE-1547 starvation concern). Must be called with the resource
+// advisory lock held so the check-then-create is serialized across maestro instances.
+func (s *sqlResourceService) republishDeleteEvent(ctx context.Context, id string) *errors.ServiceError {
+	logger := klog.FromContext(ctx).WithValues("resourceID", id)
+
+	if s.deleteEventRepublishInterval <= 0 {
+		logger.V(4).Info("skipping delete for resource as deletion is already in flight, republishing is disabled")
+		return nil
+	}
+
+	latest, svcErr := s.events.FindLatestDeleteEvent(ctx, id)
+	if svcErr != nil {
+		// best-effort healing: never fail an otherwise idempotent delete retry on the lookup
+		logger.Error(svcErr, "unable to look up the latest delete event for resource, skipping republish")
+		return nil
+	}
+
+	if latest != nil && time.Since(latest.CreatedAt) < s.deleteEventRepublishInterval {
+		logger.V(4).Info("skipping delete for resource as deletion is already in flight, delete event recently published")
+		return nil
+	}
+
+	lastDeleteEventAge := "none"
+	if latest != nil {
+		lastDeleteEventAge = time.Since(latest.CreatedAt).String()
+	}
+	if _, err := s.events.Create(ctx, &api.Event{
+		Source:    "Resources",
+		SourceID:  id,
+		EventType: api.DeleteEventType,
+	}); err != nil {
+		return handleDeleteError("Resource", err)
+	}
+	logger.Info("republishing delete event for resource stuck deleting", "lastDeleteEventAge", lastDeleteEventAge)
 
 	return nil
 }

--- a/pkg/services/resource_test.go
+++ b/pkg/services/resource_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"testing"
+	"time"
 
 	gm "github.com/onsi/gomega"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/payload"
@@ -25,7 +26,7 @@ func TestResourceFindByConsumerID(t *testing.T) {
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
 
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 60)
 
 	resources := api.ResourceList{
 		&api.Resource{ConsumerName: Fukuisaurus, Payload: newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}},{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"spec\":{\"containers\":[{\"name\":\"nginx\",\"image\":\"quay.io/nginx/nginx-unprivileged:latest\"}]},\"metadata\":{\"labels\":{\"app\":\"nginx\"}}}}}],\"deleteOption\":{\"propagationPolicy\":\"Foreground\"},\"manifestConfigs\":[{\"updateStrategy\":{\"type\":\"ServerSideApply\"},\"resourceIdentifier\":{\"name\":\"nginx\",\"group\":\"apps\",\"resource\":\"deployments\",\"namespace\":\"default\"}}]}}")},
@@ -57,7 +58,7 @@ func TestCreateInvalidResource(t *testing.T) {
 
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 60)
 
 	resource := &api.Resource{ConsumerName: "invalidation", Payload: newPayload(t, "{}")}
 
@@ -80,7 +81,7 @@ func TestMarkAsDeletingIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 60)
 
 	resource, svcErr := resourceService.Create(ctx, &api.Resource{
 		ConsumerName: Fukuisaurus,
@@ -110,13 +111,99 @@ func TestMarkAsDeletingIsIdempotent(t *testing.T) {
 	gm.Expect(countDeleteEvents()).To(gm.Equal(1))
 }
 
+// TestMarkAsDeletingRepublishesStaleDeleteEvent ensures a retried delete request for a
+// resource stuck soft-deleted re-publishes the delete event once the latest delete event
+// is older than the republish interval. A re-delivered delete event re-stamps the deletion
+// state on an agent that lost it, healing deletions that would otherwise hang forever.
+func TestMarkAsDeletingRepublishesStaleDeleteEvent(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	ctx := context.Background()
+	resourceDAO := mocks.NewResourceDao()
+	events := NewEventService(mocks.NewEventDao())
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 60)
+
+	resource, svcErr := resourceService.Create(ctx, &api.Resource{
+		ConsumerName: Fukuisaurus,
+		Payload:      newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}}]}}"),
+	})
+	gm.Expect(svcErr).To(gm.BeNil())
+
+	countDeleteEvents := func() int {
+		unreconciled, err := events.FindAllUnreconciledEvents(ctx)
+		gm.Expect(err).To(gm.BeNil())
+		count := 0
+		for _, e := range unreconciled {
+			if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+				count++
+			}
+		}
+		return count
+	}
+
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(countDeleteEvents()).To(gm.Equal(1))
+
+	// age the latest delete event past the republish interval (the mock returns pointers,
+	// so the mutation is visible to the service)
+	latest, svcErr := events.FindLatestDeleteEvent(ctx, resource.ID)
+	gm.Expect(svcErr).To(gm.BeNil())
+	gm.Expect(latest).ShouldNot(gm.BeNil())
+	latest.CreatedAt = time.Now().Add(-2 * time.Minute)
+
+	// the next retried delete republishes exactly one event
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(countDeleteEvents()).To(gm.Equal(2))
+
+	// an immediate retry is throttled by the fresh event
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+	gm.Expect(countDeleteEvents()).To(gm.Equal(2))
+}
+
+// TestMarkAsDeletingRepublishDisabled ensures a republish interval of 0 preserves the
+// pure early-return behaviour: retried deletes never enqueue another event, no matter
+// how old the latest delete event is.
+func TestMarkAsDeletingRepublishDisabled(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	ctx := context.Background()
+	resourceDAO := mocks.NewResourceDao()
+	events := NewEventService(mocks.NewEventDao())
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 0)
+
+	resource, svcErr := resourceService.Create(ctx, &api.Resource{
+		ConsumerName: Fukuisaurus,
+		Payload:      newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}}]}}"),
+	})
+	gm.Expect(svcErr).To(gm.BeNil())
+
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+
+	latest, svcErr := events.FindLatestDeleteEvent(ctx, resource.ID)
+	gm.Expect(svcErr).To(gm.BeNil())
+	gm.Expect(latest).ShouldNot(gm.BeNil())
+	latest.CreatedAt = time.Now().Add(-2 * time.Hour)
+
+	gm.Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).To(gm.BeNil())
+
+	unreconciled, err := events.FindAllUnreconciledEvents(ctx)
+	gm.Expect(err).To(gm.BeNil())
+	count := 0
+	for _, e := range unreconciled {
+		if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+			count++
+		}
+	}
+	gm.Expect(count).To(gm.Equal(1))
+}
+
 func TestResourceList(t *testing.T) {
 	gm.RegisterTestingT(t)
 
 	resourceDAO := mocks.NewResourceDao()
 	events := NewEventService(mocks.NewEventDao())
 
-	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil)
+	resourceService := NewResourceService(dbmocks.NewMockAdvisoryLockFactory(), resourceDAO, events, nil, 60)
 	resources := api.ResourceList{
 		&api.Resource{ConsumerName: Fukuisaurus, Payload: newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}},{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"spec\":{\"containers\":[{\"name\":\"nginx\",\"image\":\"quay.io/nginx/nginx-unprivileged:latest\"}]},\"metadata\":{\"labels\":{\"app\":\"nginx\"}}}}}],\"deleteOption\":{\"propagationPolicy\":\"Foreground\"},\"manifestConfigs\":[{\"updateStrategy\":{\"type\":\"ServerSideApply\"},\"resourceIdentifier\":{\"name\":\"nginx\",\"group\":\"apps\",\"resource\":\"deployments\",\"namespace\":\"default\"}}]}}")},
 		&api.Resource{ConsumerName: Fukuisaurus, Payload: newPayload(t, "{\"id\":\"266a8cd2-2fab-4e89-9bf0-a56425ebcdf8\",\"time\":\"2024-02-05T17:31:05Z\",\"type\":\"io.open-cluster-management.works.v1alpha1.manifestbundles.spec.create_request\",\"source\":\"grpc\",\"specversion\":\"1.0\",\"datacontenttype\":\"application/json\",\"resourceid\":\"c4df9ff0-bfeb-5bc6-a0ab-4c9128d698b4\",\"clustername\":\"b288a9da-8bfe-4c82-94cc-2b48e773fc46\",\"resourceversion\":1,\"data\":{\"manifests\":[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"}},{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"spec\":{\"containers\":[{\"name\":\"nginx\",\"image\":\"quay.io/nginx/nginx-unprivileged:latest\"}]},\"metadata\":{\"labels\":{\"app\":\"nginx\"}}}}}],\"deleteOption\":{\"propagationPolicy\":\"Foreground\"},\"manifestConfigs\":[{\"updateStrategy\":{\"type\":\"ServerSideApply\"},\"resourceIdentifier\":{\"name\":\"nginx\",\"group\":\"apps\",\"resource\":\"deployments\",\"namespace\":\"default\"}}]}}")},

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -584,6 +584,106 @@ func TestReconcileStaleDeleteEvents(t *testing.T) {
 	Expect(pendingDeletes()).To(Equal(0))
 }
 
+// TestMarkAsDeletingRepublishThrottle verifies that retried delete requests for a resource
+// stuck soft-deleted re-publish the delete event at most once per republish interval: a
+// re-delivered delete event re-stamps the deletion state on an agent that lost it, while
+// the throttle keeps retries from accumulating events without bound (AROSLSRE-1547).
+func TestMarkAsDeletingRepublishThrottle(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx := context.Background()
+
+	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
+	Expect(err).NotTo(HaveOccurred())
+	deployName := fmt.Sprintf("nginx-%s", rand.String(5))
+	resource, err := h.CreateResource(uuid.NewString(), consumer.Name, deployName, "default", 1)
+	Expect(err).NotTo(HaveOccurred())
+
+	resourceService := h.Env().Services.Resources()
+	eventService := h.Env().Services.Events()
+
+	pendingDeletes := func() int {
+		unreconciled, svcErr := eventService.FindAllUnreconciledEvents(ctx)
+		Expect(svcErr).NotTo(HaveOccurred())
+		count := 0
+		for _, e := range unreconciled {
+			if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+				count++
+			}
+		}
+		return count
+	}
+
+	// the first delete soft-deletes and enqueues one delete event; an immediate retry is
+	// throttled by that fresh event (default 60s interval)
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+	Expect(pendingDeletes()).To(Equal(1))
+
+	// age the delete event past the republish interval
+	g2 := h.Env().Database.SessionFactory.New(ctx)
+	Expect(g2.Exec("UPDATE events SET created_at = ? WHERE source_id = ? AND event_type = ?",
+		time.Now().Add(-2*time.Minute), resource.ID, api.DeleteEventType).Error).NotTo(HaveOccurred())
+
+	// the next retried delete republishes exactly one event, and another immediate retry
+	// is throttled again
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+	Expect(pendingDeletes()).To(Equal(2))
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+	Expect(pendingDeletes()).To(Equal(2))
+}
+
+// TestReconcileStaleDeleteEventsSparesFreshHealingEvents verifies the stale-delete
+// finalizer only retires delete events that are themselves older than the cutoff: a
+// freshly re-published healing event for a long soft-deleted resource must survive so it
+// can be delivered to the agent, otherwise the healing republish would be swallowed
+// within one detector tick.
+func TestReconcileStaleDeleteEventsSparesFreshHealingEvents(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+
+	ctx := context.Background()
+
+	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
+	Expect(err).NotTo(HaveOccurred())
+	deployName := fmt.Sprintf("nginx-%s", rand.String(5))
+	resource, err := h.CreateResource(uuid.NewString(), consumer.Name, deployName, "default", 1)
+	Expect(err).NotTo(HaveOccurred())
+
+	resourceService := h.Env().Services.Resources()
+	eventService := h.Env().Services.Events()
+
+	// soft-delete, then simulate a resource that has been stuck deleting for 2 hours with
+	// its original delete event equally old (raw SQL: gorm scopes hide soft-deleted rows)
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+	twoHoursAgo := time.Now().Add(-2 * time.Hour)
+	g2 := h.Env().Database.SessionFactory.New(ctx)
+	Expect(g2.Exec("UPDATE resources SET deleted_at = ? WHERE id = ?", twoHoursAgo, resource.ID).Error).NotTo(HaveOccurred())
+	Expect(g2.Exec("UPDATE events SET created_at = ? WHERE source_id = ? AND event_type = ?",
+		twoHoursAgo, resource.ID, api.DeleteEventType).Error).NotTo(HaveOccurred())
+
+	// a retried delete now republishes a fresh healing event
+	Expect(resourceService.MarkAsDeleting(ctx, resource.ID)).NotTo(HaveOccurred())
+
+	pendingDeletes := func() int {
+		unreconciled, svcErr := eventService.FindAllUnreconciledEvents(ctx)
+		Expect(svcErr).NotTo(HaveOccurred())
+		count := 0
+		for _, e := range unreconciled {
+			if e.SourceID == resource.ID && e.EventType == api.DeleteEventType {
+				count++
+			}
+		}
+		return count
+	}
+	Expect(pendingDeletes()).To(Equal(2))
+
+	// the detector retires only the 2h-old event; the fresh healing event survives
+	count, svcErr := eventService.ReconcileStaleDeleteEvents(ctx, time.Hour)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(count).To(Equal(int64(1)))
+	Expect(pendingDeletes()).To(Equal(1))
+}
+
 func updateWorkStatus(ctx context.Context, workClient workv1client.ManifestWorkInterface, work *workv1.ManifestWork, newStatus workv1.ManifestWorkStatus) error {
 	// update the work status
 	newWork := work.DeepCopy()


### PR DESCRIPTION
## What

Restores healing for resources stuck soft-deleted, with a hard cap. When `MarkAsDeleting` is called for a resource whose deletion is already in flight, we now re-enqueue the delete event, throttled to at most one per `--delete-event-republish-interval` (default 60s, 0 disables) per resource. The check-then-create runs under the existing per-resource advisory lock, so the cap holds across replicas.

The stale-delete detector is adjusted to match: it now only retires delete events that are themselves older than the threshold, so a fresh healing event for a long soft-deleted resource gets a full threshold of delivery attempts instead of being retired within one detector tick.

## Why

An upstream race in the OCM SDK agent store ([sdk-go#232](https://github.com/open-cluster-management-io/sdk-go/issues/232)) can erase the DeletionTimestamp from the maestro-agent's in-memory store when a delete event lands while a status patch is in flight. The agent then recreates the deleted ManifestWork on the spoke and never reports `Deleted=true`, so the server's hard-delete never fires and cluster deletion hangs until an agent reconnect happens to trigger a spec resync. We observed 16+ hours across four e2e CI runs (ARO-28958, HYPERFLEET-1497).

Before #562 (AROSLSRE-1547) every retried delete request enqueued a fresh delete event, and each re-published `delete_request` re-stamped the DeletionTimestamp in the agent store, accidentally healing the race within one retry cycle. #562 made retries silent no-ops for a good reason (the event storm was starving the spec-event worker), but that also removed the healing. This change brings the healing back deliberately: the throttle guarantees retries can never accumulate events without bound, so the AROSLSRE-1547 fix is preserved. Worst case accumulation per stuck resource is threshold/interval unreconciled rows (60 at defaults) while its agent is disconnected.

This is a bounded mitigation while the upstream fix ([sdk-go#233](https://github.com/open-cluster-management-io/sdk-go/pull/233)) is in review, and it also heals any future agent-side loss of deletion state. One caveat to be aware of: healing is driven by the client retrying deletes, which CS destructors do. Once the agent confirms the delete the resource row is hard-deleted and republishing stops naturally.

## Testing

- Unit: `TestMarkAsDeletingRepublishesStaleDeleteEvent`, `TestMarkAsDeletingRepublishDisabled`, and the existing `TestMarkAsDeletingIsIdempotent` (unchanged assertions, now also validates the throttle window). The mock event DAO now stamps `CreatedAt` on create, mirroring gorm's autoCreateTime.
- Integration (real Postgres): `TestMarkAsDeletingRepublishThrottle` (throttle + republish after backdating the event row) and `TestReconcileStaleDeleteEventsSparesFreshHealingEvents` (detector retires a 2h-old event but spares the fresh healing event on a 2h soft-deleted resource). Existing `TestReconcileStaleDeleteEvents` passes unchanged.
- Full unit suite and mqtt integration suite green locally.

Related: HYPERFLEET-1497, ARO-28958, upstream root cause sdk-go#232 / fix sdk-go#233, same symptoms in the wild [ocm#1404](https://github.com/open-cluster-management-io/ocm/issues/1404).

Note for reviewers: this touches the same `MarkAsDeleting` early-returns as the pending HYPERFLEET-1496 logging PR (#575), whichever lands second is a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USPzrSgidrmV9YrxRRf5tQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable republishing of delete events for resources that remain in a deleting state.
  - Delete-event republishing defaults to every 60 seconds and can be adjusted with a command-line setting.
  - Set the interval to zero to disable republishing.
- **Bug Fixes**
  - Prevented duplicate delete events during repeated deletion requests.
  - Improved stale-event reconciliation so recent republished events are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->