### PR TITLE
fix(metrics): remove per-resource id label to bound cardinality

### DIFF
--- a/cmd/maestro/server/event_server.go
+++ b/cmd/maestro/server/event_server.go
@@ -185,7 +185,6 @@ func HandleStatusUpdate(ctx context.Context, resource *api.Resource, resourceSer
 		timeToFirstStatusReceived := time.Since(found.CreatedAt)
 
 		services.RecordResourceFirstStatusLatencyMetric(
-			found.ID,
 			found.ConsumerName,
 			found.Source,
 			timeToFirstStatusReceived,
@@ -330,7 +329,6 @@ func broadcastStatusEvent(ctx context.Context,
 			consumerName = "unknown"
 		}
 		services.RecordResourceTimeToStatusProcessed(
-			resource.ID,
 			consumerName,
 			resource.Source,
 			instanceID,

--- a/pkg/services/resource.go
+++ b/pkg/services/resource.go
@@ -148,14 +148,9 @@ func (s *sqlResourceService) Update(ctx context.Context, resource *api.Resource)
 		return nil, handleUpdateError("Resource", err)
 	}
 
-	// Create the set of labels that we will add to all the resource process:
-	labels := prometheus.Labels{
-		metricsIDLabel:     updated.ID,
+	resourceProcessedCountMetric.With(prometheus.Labels{
 		metricsActionLabel: "update",
-	}
-
-	// Update the metric containing the number of processed resources:
-	resourceProcessedCountMetric.With(labels).Inc()
+	}).Inc()
 
 	return updated, nil
 }
@@ -244,14 +239,9 @@ func (s *sqlResourceService) UpdateStatus(ctx context.Context, resource *api.Res
 		return nil, false, handleUpdateError("Resource", err)
 	}
 
-	// Create the set of labels that we will add to all the resource process:
-	labels := prometheus.Labels{
-		metricsIDLabel:     updated.ID,
+	resourceProcessedCountMetric.With(prometheus.Labels{
 		metricsActionLabel: "update",
-	}
-
-	// Update the metric containing the number of processed resources:
-	resourceProcessedCountMetric.With(labels).Inc()
+	}).Inc()
 
 	return updated, true, nil
 }
@@ -398,7 +388,6 @@ const metricsSubsystem = "resource"
 
 // Names of the labels added to metrics:
 const (
-	metricsIDLabel       = "id"
 	metricsActionLabel   = "action"
 	metricsConsumerLabel = "consumer"
 	metricsSourceLabel   = "source"
@@ -439,7 +428,7 @@ var resourceProcessedCountMetric = prometheus.NewCounterVec(
 		Name:      processedCountMetric,
 		Help:      "Number of processed resources.",
 	},
-	[]string{metricsIDLabel, metricsActionLabel},
+	[]string{metricsActionLabel},
 )
 
 // resourceFirstStatusLatencyMetric tracks when the server first receives a status update from the agent.
@@ -451,15 +440,14 @@ var resourceFirstStatusLatencyMetric = prometheus.NewHistogramVec(
 		Help:      "Time in seconds from resource creation to when the server first receives a status update from the agent. Represents agent responsiveness and network latency.",
 		Buckets:   []float64{5.0, 30.0, 120.0, 600.0},
 	},
-	[]string{metricsIDLabel, metricsConsumerLabel, metricsSourceLabel},
+	[]string{metricsConsumerLabel, metricsSourceLabel},
 )
 
 // RecordResourceFirstStatusLatencyMetric records the latency from resource creation
 // to when the server first receives a status update from the agent.
 // This should only be called once per resource (on first status transition from empty to non-empty).
-func RecordResourceFirstStatusLatencyMetric(resourceID, consumerName, source string, latency time.Duration) {
+func RecordResourceFirstStatusLatencyMetric(consumerName, source string, latency time.Duration) {
 	labels := prometheus.Labels{
-		metricsIDLabel:       resourceID,
 		metricsConsumerLabel: consumerName,
 		metricsSourceLabel:   source,
 	}
@@ -474,10 +462,10 @@ var statusEventProcessingLatencyMetric = prometheus.NewHistogramVec(
 		Help:      "Latency in seconds from status event creation to it is processed by a server instance.",
 		Buckets:   []float64{0.05, 0.1, 0.5, 1, 5},
 	},
-	[]string{"id", "consumer", "source", "server_instance_id"},
+	[]string{"consumer", "source", "server_instance_id"},
 )
 
 // RecordResourceTimeToStatusProcessed records the time from status event creation to processing
-func RecordResourceTimeToStatusProcessed(resourceID, consumer, source, serverInstanceID string, durationSeconds float64) {
-	statusEventProcessingLatencyMetric.WithLabelValues(resourceID, consumer, source, serverInstanceID).Observe(durationSeconds)
+func RecordResourceTimeToStatusProcessed(consumer, source, serverInstanceID string, durationSeconds float64) {
+	statusEventProcessingLatencyMetric.WithLabelValues(consumer, source, serverInstanceID).Observe(durationSeconds)
 }

--- a/test/integration/resource_test.go
+++ b/test/integration/resource_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -763,12 +764,46 @@ func createStatusWithSequenceID(t *testing.T, resourceID, sequenceID string) map
 	return statusMap
 }
 
+// findHistogramSampleCount looks up a metric family by name and returns the sample count of the
+// first metric whose "consumer" and "source" labels match, along with whether it was found.
+// If serverInstanceID is non-empty, the "server_instance_id" label must also match.
+func findHistogramSampleCount(families []*dto.MetricFamily, metricName, consumer, source, serverInstanceID string) (uint64, bool) {
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			hasConsumer, hasSource, hasServerInstanceID := false, false, serverInstanceID == ""
+			for _, label := range metric.GetLabel() {
+				switch {
+				case label.GetName() == "consumer" && label.GetValue() == consumer:
+					hasConsumer = true
+				case label.GetName() == "source" && label.GetValue() == source:
+					hasSource = true
+				case label.GetName() == "server_instance_id" && label.GetValue() == serverInstanceID:
+					hasServerInstanceID = true
+				}
+			}
+			if hasConsumer && hasSource && hasServerInstanceID {
+				if metric.GetHistogram() != nil {
+					return metric.GetHistogram().GetSampleCount(), true
+				}
+				return 0, true
+			}
+		}
+	}
+	return 0, false
+}
+
 // TestFirstStatusLatencyMetric verifies that the first status latency metric
 // is collected when the server first receives a status update from the agent (in HandleStatusUpdate)
 func TestFirstStatusLatencyMetric(t *testing.T) {
 	h, _ := test.RegisterIntegration(t)
 
 	ctx := context.Background()
+
+	// Reset metrics to avoid interference from other tests
+	services.ResetResourceMetrics()
 
 	// Create a consumer and resource
 	consumer, err := h.CreateConsumer("cluster-" + rand.String(5))
@@ -807,29 +842,7 @@ func TestFirstStatusLatencyMetric(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Check for the metric
-	var foundReceived bool
-	var receivedObservationCount uint64
-	for _, mf := range metricFamily {
-		if *mf.Name == "resource_first_status_latency_seconds" {
-			for _, metric := range mf.Metric {
-				for _, label := range metric.Label {
-					if *label.Name == "id" && *label.Value == resource.ID {
-						foundReceived = true
-						if metric.Histogram != nil {
-							receivedObservationCount = *metric.Histogram.SampleCount
-						}
-						break
-					}
-				}
-				if foundReceived {
-					break
-				}
-			}
-		}
-		if foundReceived {
-			break
-		}
-	}
+	receivedObservationCount, foundReceived := findHistogramSampleCount(metricFamily, "resource_first_status_latency_seconds", consumer.Name, resource.Source, "")
 
 	Expect(foundReceived).To(BeTrue(), "Received metric should be recorded for the resource")
 	Expect(receivedObservationCount).To(Equal(uint64(1)), "Received metric should have exactly 1 observation")
@@ -851,21 +864,7 @@ func TestFirstStatusLatencyMetric(t *testing.T) {
 	metricFamily2, err := prometheus.DefaultGatherer.Gather()
 	Expect(err).NotTo(HaveOccurred())
 
-	var receivedObservationCount2 uint64
-	for _, mf := range metricFamily2 {
-		if *mf.Name == "resource_first_status_latency_seconds" {
-			for _, metric := range mf.Metric {
-				for _, label := range metric.Label {
-					if *label.Name == "id" && *label.Value == resource.ID {
-						if metric.Histogram != nil {
-							receivedObservationCount2 = *metric.Histogram.SampleCount
-						}
-						break
-					}
-				}
-			}
-		}
-	}
+	receivedObservationCount2, _ := findHistogramSampleCount(metricFamily2, "resource_first_status_latency_seconds", consumer.Name, resource.Source, "")
 
 	Expect(receivedObservationCount2).To(Equal(uint64(1)), "Received metric count should remain 1 after second status update")
 }
@@ -916,46 +915,24 @@ func TestStatusEventProcessingLatencyMetric(t *testing.T) {
 	h.ControllerManager.StatusController.AddStatusEvent(statusEvent.ID)
 
 	// Verify the metric was recorded
-	// The metric should have been recorded with labels: id, consumer, source, server_instance_id
+	// The metric should have been recorded with labels: consumer, source, server_instance_id
 	metricName := "resource_status_event_processing_latency_seconds"
 
 	// Wait for the status event to be processed and metric to be recorded
+	serverInstanceID := h.Env().Config.MessageBroker.ClientID
 	Eventually(func() error {
 		families, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
 			return err
 		}
 
-		for _, mf := range families {
-			if mf.GetName() == metricName {
-				for _, m := range mf.GetMetric() {
-					labels := m.GetLabel()
-					hasCorrectResourceID := false
-					hasCorrectConsumer := false
-					hasCorrectSource := false
-
-					for _, label := range labels {
-						if label.GetName() == "id" && label.GetValue() == resource.ID {
-							hasCorrectResourceID = true
-						}
-						if label.GetName() == "consumer" && label.GetValue() == consumer.Name {
-							hasCorrectConsumer = true
-						}
-						if label.GetName() == "source" && label.GetValue() == resource.Source {
-							hasCorrectSource = true
-						}
-					}
-
-					if hasCorrectResourceID && hasCorrectConsumer && hasCorrectSource {
-						// Verify that at least one observation was recorded
-						if m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
-							return nil
-						}
-						return fmt.Errorf("metric found with correct labels but no samples recorded")
-					}
-				}
-			}
+		sampleCount, found := findHistogramSampleCount(families, metricName, consumer.Name, resource.Source, serverInstanceID)
+		if !found {
+			return fmt.Errorf("metric %s not found with correct labels (consumer=%s, source=%s, server_instance_id=%s)", metricName, consumer.Name, resource.Source, serverInstanceID)
 		}
-		return fmt.Errorf("metric %s not found with correct labels (id=%s, consumer=%s, source=%s)", metricName, resource.ID, consumer.Name, resource.Source)
+		if sampleCount == 0 {
+			return fmt.Errorf("metric found with correct labels but no samples recorded")
+		}
+		return nil
 	}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 }


### PR DESCRIPTION
## Description

`resource_processed_total`, `resource_first_status_latency_seconds`, and `resource_status_event_processing_latency_seconds` were labeled with the resource `id`. Since `id` is unique per resource and Maestro is designed to scale to a lot of resources, this creates one time series per resource, growing without bound as resources come and go.

This PR drops `id` from all three metrics, keeping `action`, `consumer`, `source`, and `server_instance_id`.

The two histograms were, per-resource, always a single observation — not a distribution. Without `id`, observations for the same `consumer`/`source` accumulate into one histogram, so `histogram_quantile()` now gives real p50/p95/p99 latency — actually alertable. Per-resource latency was never queryable at that granularity anyway; it belongs in logs (already logged at each call site).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-processing metrics by removing resource ID labels.
  * Updated latency metrics to use consumer and source labels for clearer aggregation.
  * Maintained existing event processing behavior while improving metric consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->