### PR TITLE
fix(server): tie healthcheck and heartbeat pulse to CloudEvents transport readiness

### DIFF
--- a/.claude/skills/setup-maestro-cluster/SKILL.md
+++ b/.claude/skills/setup-maestro-cluster/SKILL.md
@@ -18,7 +18,7 @@ Sets up a long-running Maestro cluster environment using Azure ARO-HCP infrastru
 - `USER=oasis` (if not already set)
 - `PERSIST=true`
 - `GITHUB_ACTIONS=true`
-- `GOTOOLCHAIN=go1.26.0`
+- `GOTOOLCHAIN=go1.26.7`
 
 **Note:** This deployment typically takes 25-30 minutes to complete.
 

--- a/.claude/skills/setup-maestro-cluster/SKILL.md
+++ b/.claude/skills/setup-maestro-cluster/SKILL.md
@@ -18,7 +18,7 @@ Sets up a long-running Maestro cluster environment using Azure ARO-HCP infrastru
 - `USER=oasis` (if not already set)
 - `PERSIST=true`
 - `GITHUB_ACTIONS=true`
-- `GOTOOLCHAIN=go1.24.4`
+- `GOTOOLCHAIN=go1.26.0`
 
 **Note:** This deployment typically takes 25-30 minutes to complete.
 

--- a/.claude/skills/setup-maestro-cluster/scripts/setup.sh
+++ b/.claude/skills/setup-maestro-cluster/scripts/setup.sh
@@ -123,7 +123,7 @@ else
     export PERSIST="${PERSIST:-true}"
 fi
 export GITHUB_ACTIONS=true
-export GOTOOLCHAIN=go1.26.0
+export GOTOOLCHAIN=go1.26.7
 
 echo "USER=$USER"
 echo "PERSIST=$PERSIST"

--- a/.claude/skills/setup-maestro-cluster/scripts/setup.sh
+++ b/.claude/skills/setup-maestro-cluster/scripts/setup.sh
@@ -123,7 +123,7 @@ else
     export PERSIST="${PERSIST:-true}"
 fi
 export GITHUB_ACTIONS=true
-export GOTOOLCHAIN=go1.24.4
+export GOTOOLCHAIN=go1.26.0
 
 echo "USER=$USER"
 echo "PERSIST=$PERSIST"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -48,7 +48,7 @@ spec:
             dnf -y install jq git make
 
             # Install golang with a given version
-            export GOVERSION=1.26.0
+            export GOVERSION=1.26.7
             curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -48,7 +48,7 @@ spec:
             dnf -y install jq git make
 
             # Install golang with a given version
-            export GOVERSION=1.25.0
+            export GOVERSION=1.26.0
             curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/.tekton/unit-test.yaml
+++ b/.tekton/unit-test.yaml
@@ -48,7 +48,7 @@ spec:
             dnf -y install jq git make
 
             # Install golang with a given version
-            export GOVERSION=1.26.0
+            export GOVERSION=1.26.7
             curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/.tekton/unit-test.yaml
+++ b/.tekton/unit-test.yaml
@@ -48,7 +48,7 @@ spec:
             dnf -y install jq git make
 
             # Install golang with a given version
-            export GOVERSION=1.25.0
+            export GOVERSION=1.26.0
             curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Supports two message broker types:
 - Performance tests in `test/performance/`
 
 ## Development Environment
-- Go 1.24.4+ required
+- Go 1.26.0+ required
 - PostgreSQL 17.2 for database
 - Eclipse Mosquitto 2.0.18 for MQTT broker (if using MQTT mode)
 - OpenShift CLI (`oc`) for deployment

--- a/Dockerfile.openapi
+++ b/Dockerfile.openapi
@@ -2,8 +2,8 @@ FROM openapitools/openapi-generator-cli:v7.24.0
 
 RUN apt-get update
 RUN apt-get install -y make sudo git
-RUN wget https://go.dev/dl/go1.26.0.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.26.7.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.7.linux-amd64.tar.gz
 
 RUN mkdir -p /local
 COPY . /local

--- a/Dockerfile.openapi
+++ b/Dockerfile.openapi
@@ -2,8 +2,8 @@ FROM openapitools/openapi-generator-cli:v7.24.0
 
 RUN apt-get update
 RUN apt-get install -y make sudo git
-RUN wget https://go.dev/dl/go1.25.5.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.25.5.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.26.0.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz
 
 RUN mkdir -p /local
 COPY . /local

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ help:
 
 # Encourage consistent tool versions
 OPENAPI_GENERATOR_VERSION:=5.4.0
-GO_VERSION:=go1.25.
+GO_VERSION:=go1.26.
 
 ### Constants:
 version:=$(shell date +%s)
@@ -174,7 +174,7 @@ verify: check-gopath verify-fmt-imports
 .PHONY: verify
 
 # Runs our linter to verify that everything is following best practices
-# Requires golangci-lint (v2, since go.mod requires go >= 1.25 which is only supported by
+# Requires golangci-lint (v2, since go.mod requires go >= 1.26 which is only supported by
 # golangci-lint v2) to be installed @ $(go env GOPATH)/bin/golangci-lint
 # Linter is set to ignore `unused` stuff due to example being incomplete by definition
 lint:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ See the [Server Command](./docs/cli/server.md#quick-start) for details.
 
 ### Prerequisites
 
-- Go 1.24.4+
+- Go 1.26.0+
 - PostgreSQL 17.2
 - Container runtime (podman or docker)
 - Eclipse Mosquitto 2.0.18 (for MQTT mode)

--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -91,11 +91,18 @@ func (s *HealthCheckServer) Start(ctx context.Context) {
 	s.httpServer.Shutdown(context.Background())
 }
 
+// cloudEventsNotReady reports whether the CloudEvents source client is expected
+// to be ready but is not. It returns false when the message broker is disabled or
+// no source client is configured, since there is no CloudEvents transport to gate on.
+func (s *HealthCheckServer) cloudEventsNotReady() bool {
+	return !env().Config.MessageBroker.Disable && s.sourceClient != nil && !s.sourceClient.IsReady()
+}
+
 func (s *HealthCheckServer) pulse(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 
 	// Check CloudEvents source client readiness if configured and broker is enabled
-	if !env().Config.MessageBroker.Disable && s.sourceClient != nil && !s.sourceClient.IsReady() {
+	if s.cloudEventsNotReady() {
 		logger.Info("CloudEvents source client is not ready, skipping heartbeat pulse", "instanceID", s.instanceID)
 		return
 	}
@@ -190,8 +197,8 @@ func (s *HealthCheckServer) checkInstances(ctx context.Context) {
 func (s *HealthCheckServer) healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	logger := klog.FromContext(r.Context()).WithValues("instanceID", s.instanceID)
 
-	if !env().Config.MessageBroker.Disable && s.sourceClient != nil && !s.sourceClient.IsReady() {
-		logger.Info("CloudEvents source client is not ready", "instanceID", s.instanceID)
+	if s.cloudEventsNotReady() {
+		logger.Info("CloudEvents source client is not ready")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err := w.Write([]byte(`{"status": "cloudevents client not ready"}`))
 		if err != nil {

--- a/cmd/maestro/server/healthcheck_server.go
+++ b/cmd/maestro/server/healthcheck_server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift-online/maestro/cmd/maestro/server/logging"
 	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/client/cloudevents"
 	"github.com/openshift-online/maestro/pkg/dao"
 	"github.com/openshift-online/maestro/pkg/db"
 )
@@ -25,6 +26,7 @@ type HealthCheckServer struct {
 	instanceID        string
 	heartbeatInterval int
 	brokerType        string
+	sourceClient      cloudevents.SourceClient
 }
 
 func NewHealthCheckServer(ctx context.Context) *HealthCheckServer {
@@ -43,6 +45,7 @@ func NewHealthCheckServer(ctx context.Context) *HealthCheckServer {
 		instanceID:        env().Config.MessageBroker.ClientID,
 		heartbeatInterval: env().Config.HealthCheck.HeartbeartInterval,
 		brokerType:        env().Config.MessageBroker.MessageBrokerType,
+		sourceClient:      env().Clients.CloudEventsSource,
 	}
 
 	router.HandleFunc("/healthcheck", server.healthCheckHandler).Methods(http.MethodGet)
@@ -90,6 +93,13 @@ func (s *HealthCheckServer) Start(ctx context.Context) {
 
 func (s *HealthCheckServer) pulse(ctx context.Context) {
 	logger := klog.FromContext(ctx)
+
+	// Check CloudEvents source client readiness if configured and broker is enabled
+	if !env().Config.MessageBroker.Disable && s.sourceClient != nil && !s.sourceClient.IsReady() {
+		logger.Info("CloudEvents source client is not ready, skipping heartbeat pulse", "instanceID", s.instanceID)
+		return
+	}
+
 	// If there are multiple requests at the same time, it will cause the race conditions among these
 	// requests (read–modify–write), the advisory lock is used here to prevent the race conditions.
 	lockOwnerID, err := s.lockFactory.NewAdvisoryLock(ctx, s.instanceID, db.Instances)
@@ -179,6 +189,17 @@ func (s *HealthCheckServer) checkInstances(ctx context.Context) {
 // healthCheckHandler returns a 200 OK if the instance is ready, 503 Service Unavailable otherwise.
 func (s *HealthCheckServer) healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	logger := klog.FromContext(r.Context()).WithValues("instanceID", s.instanceID)
+
+	if !env().Config.MessageBroker.Disable && s.sourceClient != nil && !s.sourceClient.IsReady() {
+		logger.Info("CloudEvents source client is not ready", "instanceID", s.instanceID)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte(`{"status": "cloudevents client not ready"}`))
+		if err != nil {
+			logger.Error(err, "Error writing healthcheck response")
+		}
+		return
+	}
+
 	instance, err := s.instanceDao.Get(r.Context(), s.instanceID)
 	if err != nil {
 		logger.Error(err, "Error getting instance")

--- a/cmd/maestro/server/healthcheck_server_test.go
+++ b/cmd/maestro/server/healthcheck_server_test.go
@@ -79,6 +79,12 @@ func (m *mockCEClient) SubscribedChan() <-chan struct{}                      { r
 func (m *mockCEClient) IsReady() bool                                        { return m.ready }
 
 func TestHealthCheckHandler_CloudEventsReadiness(t *testing.T) {
+	origDisable := env().Config.MessageBroker.Disable
+	t.Cleanup(func() {
+		env().Config.MessageBroker.Disable = origDisable
+	})
+	env().Config.MessageBroker.Disable = false
+
 	tests := []struct {
 		name           string
 		instanceReady  bool
@@ -169,6 +175,12 @@ func TestLivenessHandler(t *testing.T) {
 }
 
 func TestPulse_SkipsHeartbeatWhenCloudEventsNotReady(t *testing.T) {
+	origDisable := env().Config.MessageBroker.Disable
+	t.Cleanup(func() {
+		env().Config.MessageBroker.Disable = origDisable
+	})
+	env().Config.MessageBroker.Disable = false
+
 	initialHeartbeat := time.Now().Add(-10 * time.Minute)
 	instanceDao := &mockInstanceDao{
 		instance: &api.ServerInstance{
@@ -205,5 +217,27 @@ func TestPulse_SkipsHeartbeatWhenCloudEventsNotReady(t *testing.T) {
 	}
 	if !instanceDao.instance.LastHeartbeat.After(initialHeartbeat) {
 		t.Errorf("expected LastHeartbeat to be updated, got %v", instanceDao.instance.LastHeartbeat)
+	}
+}
+
+func TestCloudEventsNotReady_SkippedWhenMessageBrokerDisabled(t *testing.T) {
+	origDisable := env().Config.MessageBroker.Disable
+	t.Cleanup(func() {
+		env().Config.MessageBroker.Disable = origDisable
+	})
+
+	server := &HealthCheckServer{
+		instanceID:   "test-instance",
+		sourceClient: &mockCEClient{ready: false},
+	}
+
+	env().Config.MessageBroker.Disable = true
+	if server.cloudEventsNotReady() {
+		t.Errorf("expected cloudEventsNotReady to be false when message broker is disabled, even if source client reports not ready")
+	}
+
+	env().Config.MessageBroker.Disable = false
+	if !server.cloudEventsNotReady() {
+		t.Errorf("expected cloudEventsNotReady to be true when message broker is enabled and source client is not ready")
 	}
 }

--- a/cmd/maestro/server/healthcheck_server_test.go
+++ b/cmd/maestro/server/healthcheck_server_test.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cegeneric "open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
+
+	"github.com/openshift-online/maestro/pkg/api"
+	"github.com/openshift-online/maestro/pkg/db"
+)
+
+type mockInstanceDao struct {
+	instance *api.ServerInstance
+	getErr   error
+	replaced *api.ServerInstance
+}
+
+func (m *mockInstanceDao) Get(ctx context.Context, id string) (*api.ServerInstance, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.instance, nil
+}
+
+func (m *mockInstanceDao) Create(ctx context.Context, instance *api.ServerInstance) (*api.ServerInstance, error) {
+	m.instance = instance
+	return instance, nil
+}
+
+func (m *mockInstanceDao) Replace(ctx context.Context, instance *api.ServerInstance) (*api.ServerInstance, error) {
+	m.replaced = instance
+	m.instance = instance
+	return instance, nil
+}
+
+func (m *mockInstanceDao) MarkReadyByIDs(ctx context.Context, ids []string) error   { return nil }
+func (m *mockInstanceDao) MarkUnreadyByIDs(ctx context.Context, ids []string) error { return nil }
+func (m *mockInstanceDao) Delete(ctx context.Context, id string) error              { return nil }
+func (m *mockInstanceDao) DeleteByIDs(ctx context.Context, ids []string) error      { return nil }
+func (m *mockInstanceDao) FindByIDs(ctx context.Context, ids []string) (api.ServerInstanceList, error) {
+	return nil, nil
+}
+func (m *mockInstanceDao) FindByUpdatedTime(ctx context.Context, updatedTime time.Time) (api.ServerInstanceList, error) {
+	return nil, nil
+}
+func (m *mockInstanceDao) FindReadyIDs(ctx context.Context) ([]string, error) { return nil, nil }
+func (m *mockInstanceDao) All(ctx context.Context) (api.ServerInstanceList, error) {
+	if m.instance != nil {
+		return api.ServerInstanceList{m.instance}, nil
+	}
+	return nil, nil
+}
+
+type mockLockFactory struct{}
+
+func (m *mockLockFactory) NewAdvisoryLock(ctx context.Context, id string, lockType db.LockType) (string, error) {
+	return "test-lock", nil
+}
+func (m *mockLockFactory) NewNonBlockingLock(ctx context.Context, id string, lockType db.LockType) (string, bool, error) {
+	return "test-lock", true, nil
+}
+func (m *mockLockFactory) Unlock(ctx context.Context, uuid string) {}
+
+type mockCEClient struct {
+	ready bool
+}
+
+func (m *mockCEClient) OnCreate(ctx context.Context, id string) error { return nil }
+func (m *mockCEClient) OnUpdate(ctx context.Context, id string) error { return nil }
+func (m *mockCEClient) OnDelete(ctx context.Context, id string) error { return nil }
+func (m *mockCEClient) Subscribe(ctx context.Context, handlers ...cegeneric.ResourceHandler[*api.Resource]) {
+}
+func (m *mockCEClient) Resync(ctx context.Context, consumers []string) error { return nil }
+func (m *mockCEClient) SubscribedChan() <-chan struct{}                      { return nil }
+func (m *mockCEClient) IsReady() bool                                        { return m.ready }
+
+func TestHealthCheckHandler_CloudEventsReadiness(t *testing.T) {
+	tests := []struct {
+		name           string
+		instanceReady  bool
+		ceClientReady  bool
+		hasClient      bool
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "healthy when instance ready and cloudevents ready",
+			instanceReady:  true,
+			ceClientReady:  true,
+			hasClient:      true,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"status": "ok"}`,
+		},
+		{
+			name:           "unhealthy when cloudevents client not ready even if instance ready in DB",
+			instanceReady:  true,
+			ceClientReady:  false,
+			hasClient:      true,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   `{"status": "cloudevents client not ready"}`,
+		},
+		{
+			name:           "unhealthy when instance not ready in DB",
+			instanceReady:  false,
+			ceClientReady:  true,
+			hasClient:      true,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   `{"status": "not ready"}`,
+		},
+		{
+			name:           "healthy when no cloudevents client and instance ready",
+			instanceReady:  true,
+			hasClient:      false,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"status": "ok"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instanceDao := &mockInstanceDao{
+				instance: &api.ServerInstance{
+					Meta:          api.Meta{ID: "test-instance"},
+					Ready:         tt.instanceReady,
+					LastHeartbeat: time.Now(),
+				},
+			}
+
+			server := &HealthCheckServer{
+				instanceDao: instanceDao,
+				instanceID:  "test-instance",
+			}
+			if tt.hasClient {
+				server.sourceClient = &mockCEClient{ready: tt.ceClientReady}
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+			rec := httptest.NewRecorder()
+
+			server.healthCheckHandler(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+			if rec.Body.String() != tt.expectedBody {
+				t.Errorf("expected body %q, got %q", tt.expectedBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLivenessHandler(t *testing.T) {
+	server := &HealthCheckServer{instanceID: "test-instance"}
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+
+	server.livenessHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if rec.Body.String() != `{"status": "ok"}` {
+		t.Errorf("expected body %q, got %q", `{"status": "ok"}`, rec.Body.String())
+	}
+}
+
+func TestPulse_SkipsHeartbeatWhenCloudEventsNotReady(t *testing.T) {
+	initialHeartbeat := time.Now().Add(-10 * time.Minute)
+	instanceDao := &mockInstanceDao{
+		instance: &api.ServerInstance{
+			Meta:          api.Meta{ID: "test-instance"},
+			Ready:         true,
+			LastHeartbeat: initialHeartbeat,
+		},
+	}
+
+	server := &HealthCheckServer{
+		instanceDao:  instanceDao,
+		lockFactory:  &mockLockFactory{},
+		instanceID:   "test-instance",
+		sourceClient: &mockCEClient{ready: false},
+	}
+
+	ctx := context.Background()
+	server.pulse(ctx)
+
+	// Heartbeat should NOT be updated because CloudEvents client is not ready
+	if instanceDao.replaced != nil {
+		t.Errorf("expected pulse to skip heartbeat update when CloudEvents client not ready, but replaced was called")
+	}
+	if !instanceDao.instance.LastHeartbeat.Equal(initialHeartbeat) {
+		t.Errorf("expected LastHeartbeat to remain unchanged, got %v", instanceDao.instance.LastHeartbeat)
+	}
+
+	// Now mark CloudEvents client ready and verify pulse updates heartbeat
+	server.sourceClient = &mockCEClient{ready: true}
+	server.pulse(ctx)
+
+	if instanceDao.replaced == nil {
+		t.Errorf("expected pulse to update heartbeat when CloudEvents client is ready")
+	}
+	if !instanceDao.instance.LastHeartbeat.After(initialHeartbeat) {
+		t.Errorf("expected LastHeartbeat to be updated, got %v", instanceDao.instance.LastHeartbeat)
+	}
+}

--- a/cmd/maestro/server/healthcheck_server_test.go
+++ b/cmd/maestro/server/healthcheck_server_test.go
@@ -144,7 +144,7 @@ func TestHealthCheckHandler_CloudEventsReadiness(t *testing.T) {
 				server.sourceClient = &mockCEClient{ready: tt.ceClientReady}
 			}
 
-			req := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/healthcheck", nil)
 			rec := httptest.NewRecorder()
 
 			server.healthCheckHandler(rec, req)
@@ -161,7 +161,7 @@ func TestHealthCheckHandler_CloudEventsReadiness(t *testing.T) {
 
 func TestLivenessHandler(t *testing.T) {
 	server := &HealthCheckServer{instanceID: "test-instance"}
-	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", nil)
 	rec := httptest.NewRecorder()
 
 	server.livenessHandler(rec, req)

--- a/go.mod
+++ b/go.mod
@@ -58,11 +58,9 @@ require (
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558
 	open-cluster-management.io/ocm v1.2.1
-	open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b
+	open-cluster-management.io/sdk-go v1.3.1-0.20260823160543-f14d74fb98ee
 	sigs.k8s.io/yaml v1.6.0
 )
-
-replace open-cluster-management.io/sdk-go => github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-online/maestro
 
-go 1.25.13
+go 1.26.0
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.3.0
@@ -62,7 +62,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-replace open-cluster-management.io/sdk-go => ../sdk-go
+replace open-cluster-management.io/sdk-go => github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -56,11 +56,13 @@ require (
 	k8s.io/component-base v0.35.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf
+	open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558
 	open-cluster-management.io/ocm v1.2.1
 	open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b
 	sigs.k8s.io/yaml v1.6.0
 )
+
+replace open-cluster-management.io/sdk-go => ../sdk-go
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -790,12 +790,10 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf h1:SnLaZD2QHz+Ep2SfVKx9y5WIMmyLnQcEv/ySW8k/NXc=
-open-cluster-management.io/api v1.2.1-0.20260305152611-5bfebdbc3fdf/go.mod h1:ZpXs1bFTIIqKstMHdLO9IY0NFlbCvZgEtByvvNSmab0=
+open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558 h1:Ny12QGibGK2KAZ9KM0E89+jeqmYtQQi3fpi1dOLG5SA=
+open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558/go.mod h1:/qLKuMbMS1+MpirTjaw4BoS3INKG8jV3s5J7iju48tg=
 open-cluster-management.io/ocm v1.2.1 h1:JC1mrIkaNjJ+AmLjiQ/sIhUE6Uzb3JVXFlFbaZF5+VY=
 open-cluster-management.io/ocm v1.2.1/go.mod h1:7jQB00gs+BxpvPTWvEWZ7x6RrkgqxLkVpqLpaCLmG8c=
-open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b h1:C919NhpIzPJO8iKzvej5gRhZV5S5rapa/YCznkjUPcU=
-open-cluster-management.io/sdk-go v1.2.1-0.20260323031834-e885ccee3f1b/go.mod h1:lDef+5BvifXww0S7cseux+Wi8melkH29bAf33OZ0ZVg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,6 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.0/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92 h1:OyZ3CnTbBQZ8Wpowh8meugNw9FceyLojhdCqmHqpNLE=
-github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92/go.mod h1:j2M5g9Shhgvh9Y79/T7ZI1iyokZKaZ7ricRa9yHrzd8=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -796,6 +794,8 @@ open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558 h1:Ny12QGibG
 open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558/go.mod h1:/qLKuMbMS1+MpirTjaw4BoS3INKG8jV3s5J7iju48tg=
 open-cluster-management.io/ocm v1.2.1 h1:JC1mrIkaNjJ+AmLjiQ/sIhUE6Uzb3JVXFlFbaZF5+VY=
 open-cluster-management.io/ocm v1.2.1/go.mod h1:7jQB00gs+BxpvPTWvEWZ7x6RrkgqxLkVpqLpaCLmG8c=
+open-cluster-management.io/sdk-go v1.3.1-0.20260823160543-f14d74fb98ee h1:jgqbyyI9wz/v/uWjBVO0QazPKVbHHDg/E19aktvbwqU=
+open-cluster-management.io/sdk-go v1.3.1-0.20260823160543-f14d74fb98ee/go.mod h1:j2M5g9Shhgvh9Y79/T7ZI1iyokZKaZ7ricRa9yHrzd8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.0/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92 h1:OyZ3CnTbBQZ8Wpowh8meugNw9FceyLojhdCqmHqpNLE=
+github.com/jnpacker/sdk-go v0.0.0-20260821192238-8d84f924bf92/go.mod h1:j2M5g9Shhgvh9Y79/T7ZI1iyokZKaZ7ricRa9yHrzd8=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/pkg/client/cloudevents/source_client.go
+++ b/pkg/client/cloudevents/source_client.go
@@ -31,6 +31,7 @@ type SourceClient interface {
 	Subscribe(ctx context.Context, handlers ...cegeneric.ResourceHandler[*api.Resource])
 	Resync(ctx context.Context, consumers []string) error
 	SubscribedChan() <-chan struct{}
+	IsReady() bool
 }
 
 type SourceClientImpl struct {
@@ -277,6 +278,13 @@ func (s *SourceClientImpl) sendResyncBatch(ctx context.Context, consumer string,
 
 func (s *SourceClientImpl) SubscribedChan() <-chan struct{} {
 	return s.CloudEventSourceClient.SubscribedChan()
+}
+
+func (s *SourceClientImpl) IsReady() bool {
+	if s.CloudEventSourceClient == nil {
+		return false
+	}
+	return s.CloudEventSourceClient.IsReady()
 }
 
 // ResourceStatusHashGetter returns a hash of the resource status.

--- a/pkg/client/cloudevents/source_client_mock.go
+++ b/pkg/client/cloudevents/source_client_mock.go
@@ -33,6 +33,7 @@ type SourceClientMock struct {
 	agent           string
 	resources       api.ResourceList
 	ResourceService services.ResourceService
+	NotReady        bool
 }
 
 var _ SourceClient = &SourceClientMock{}
@@ -177,4 +178,8 @@ func (s *SourceClientMock) Resync(ctx context.Context, consumers []string) error
 
 func (s *SourceClientMock) SubscribedChan() <-chan struct{} {
 	return nil
+}
+
+func (s *SourceClientMock) IsReady() bool {
+	return !s.NotReady
 }

--- a/pkg/client/cloudevents/source_client_mock.go
+++ b/pkg/client/cloudevents/source_client_mock.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bwmarrin/snowflake"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/payload"
 	workpayload "open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/payload"
 	cegeneric "open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
@@ -64,7 +63,7 @@ func (s *SourceClientMock) OnCreate(ctx context.Context, id string) error {
 		WithOriginalSource("maestro").
 		NewEvent()
 
-	manifestBundleStatus := &payload.ManifestBundleStatus{
+	manifestBundleStatus := &workpayload.ManifestBundleStatus{
 		Conditions: []metav1.Condition{
 			{
 				Type:               "Applied",

--- a/pkg/client/cloudevents/source_client_test.go
+++ b/pkg/client/cloudevents/source_client_test.go
@@ -327,3 +327,27 @@ func TestResyncConsumerEventStructure(t *testing.T) {
 	Expect(list2.Hashes).To(HaveLen(1))
 	Expect(list2.Hashes[0].StatusHash).NotTo(BeEmpty())
 }
+
+// TestSourceClientImplIsReady verifies that IsReady returns false when the underlying
+// CloudEventSourceClient is nil.
+func TestSourceClientImplIsReady(t *testing.T) {
+	RegisterTestingT(t)
+
+	// When CloudEventSourceClient is nil
+	client := &SourceClientImpl{}
+	Expect(client.IsReady()).To(BeFalse())
+}
+
+// TestSourceClientMockIsReady verifies that SourceClientMock.IsReady reflects the NotReady flag.
+func TestSourceClientMockIsReady(t *testing.T) {
+	RegisterTestingT(t)
+
+	mock := &SourceClientMock{}
+	Expect(mock.IsReady()).To(BeTrue())
+
+	mock.NotReady = true
+	Expect(mock.IsReady()).To(BeFalse())
+
+	mock.NotReady = false
+	Expect(mock.IsReady()).To(BeTrue())
+}

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -18,7 +18,7 @@ function cleanUp {
 }
 trap cleanUp EXIT
 
-test -f go1.26.0.linux-amd64.tar.gz || curl -O -J https://dl.google.com/go/go1.26.0.linux-amd64.tar.gz
+test -f go1.26.7.linux-amd64.tar.gz || curl -O -J https://dl.google.com/go/go1.26.7.linux-amd64.tar.gz
 
 podman build -t "$IMAGE_NAME" -f Dockerfile.test .
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -18,7 +18,7 @@ function cleanUp {
 }
 trap cleanUp EXIT
 
-test -f go1.23.4.linux-amd64.tar.gz || curl -O -J https://dl.google.com/go/go1.23.4.linux-amd64.tar.gz
+test -f go1.26.0.linux-amd64.tar.gz || curl -O -J https://dl.google.com/go/go1.26.0.linux-amd64.tar.gz
 
 podman build -t "$IMAGE_NAME" -f Dockerfile.test .
 

--- a/test/README.md
+++ b/test/README.md
@@ -391,7 +391,7 @@ The manual E2E test performs the same upgrade testing sequence as the long runni
 
 ### Prerequisites
 
-- Go 1.24.4+
+- Go 1.26.0+
 - Docker or Podman
 - PostgreSQL (for integration tests)
 - Eclipse Mosquitto (for MQTT tests)


### PR DESCRIPTION
## Description

- **Executive summary**:
  - Ties Maestro server's `/healthcheck` readiness probe and PostgreSQL heartbeat pulsing to CloudEvents transport readiness (`SourceClient.IsReady()`).
  - When the message broker connection drops or enters a wedged state, `/healthcheck` immediately returns `503 Service Unavailable` (`{"status": "cloudevents client not ready"}`) and `pulse()` stops updating the database heartbeat, causing the instance to be marked unready and evicted from the consistent hash ring so healthy replicas take over consumer assignments.
  - `/livez` probe remains unaffected (returns 200 OK) to prevent transient network/DB hiccups from triggering destructive Kubernetes restart loops.

- **Detailed implementation summary**:
  - `pkg/client/cloudevents/source_client.go`:
    - Added `IsReady() bool` to `SourceClient` interface and implemented it in `SourceClientImpl` by delegating to `CloudEventSourceClient.IsReady()`.
  - `pkg/client/cloudevents/source_client_mock.go`:
    - Added `NotReady` field and `IsReady() bool` to `SourceClientMock` for testing readiness transitions.
  - `cmd/maestro/server/healthcheck_server.go`:
    - Injected `sourceClient` into `HealthCheckServer`.
    - In `pulse()`, skips database heartbeat update when `sourceClient` is not ready.
    - In `healthCheckHandler`, returns `503 Service Unavailable` with `{"status": "cloudevents client not ready"}` when `sourceClient` is not ready.
  - Tests added:
    - `cmd/maestro/server/healthcheck_server_test.go`:
      - `TestHealthCheckHandler_CloudEventsReadiness`: verifies 200 OK when ready and 503 when CloudEvents client is unready.
      - `TestLivenessHandler`: verifies `/livez` returns 200 OK.
      - `TestPulse_SkipsHeartbeatWhenCloudEventsNotReady`: verifies heartbeat pulse skipping and recovery.

- **Jira link**:
  - [ACM-42606](https://redhat.atlassian.net/browse/ACM-42606)
  - Related: [AROSLSRE-1844](https://redhat.atlassian.net/browse/AROSLSRE-1844)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

- [x] Unit tests pass (`make test` / `go test -v ./pkg/client/cloudevents/... ./cmd/maestro/server/...`)
- [x] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health checks now verify that the configured CloudEvents connection is ready.
  - Readiness checks return HTTP 503 when CloudEvents is unavailable.
  - Heartbeat updates pause until the CloudEvents connection becomes ready.

- **Bug Fixes**
  - Improved health and liveness behavior for unavailable event connections.

- **Documentation**
  - Updated setup, build, and testing requirements to Go 1.26.

- **Tests**
  - Added coverage for readiness, liveness, and heartbeat behavior during connection startup or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->