### PR TITLE
fix(chart): use /livez for maestro-server liveness probe

### DIFF
--- a/charts/maestro-server/templates/deployment.yaml
+++ b/charts/maestro-server/templates/deployment.yaml
@@ -179,7 +179,7 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /livez
             port: {{ .Values.server.healthCheck.bindPort }}
             scheme: {{ if .Values.server.https.enabled }}HTTPS{{ else }}HTTP{{ end }}
           initialDelaySeconds: 25

--- a/cmd/maestro/server/healthcheck_chart_probe_paths_test.go
+++ b/cmd/maestro/server/healthcheck_chart_probe_paths_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMaestroServerChartProbePaths(t *testing.T) {
+	content, err := os.ReadFile("../../../charts/maestro-server/templates/deployment.yaml")
+	if err != nil {
+		t.Fatalf("failed to read chart deployment template: %v", err)
+	}
+
+	tpl := string(content)
+	if !strings.Contains(tpl, "livenessProbe:\n          httpGet:\n            path: /livez") {
+		t.Fatalf("expected liveness probe path to be /livez")
+	}
+
+	if !strings.Contains(tpl, "readinessProbe:\n          httpGet:\n            path: /healthcheck") {
+		t.Fatalf("expected readiness probe path to remain /healthcheck")
+	}
+}


### PR DESCRIPTION
## Executive Summary
- Switch Maestro server liveness probing to `/livez` so kubelet process-health checks stay independent from transport/data-plane readiness.
- Keep readiness probing on `/healthcheck` so CloudEvents/DB readiness still controls endpoint availability.
- Add regression coverage to prevent future chart probe-path drift.

## Detailed Implementation Summary
- Updated `charts/maestro-server/templates/deployment.yaml`:
  - `livenessProbe.httpGet.path` changed from `/healthcheck` to `/livez`.
  - `readinessProbe.httpGet.path` remains `/healthcheck`.
- Added `cmd/maestro/server/healthcheck_chart_probe_paths_test.go`:
  - Asserts chart template contains `/livez` for liveness.
  - Asserts chart template contains `/healthcheck` for readiness.
- Validation performed:
  - `go test ./cmd/maestro/server -run TestMaestroServerChartProbePaths -count=1`
  - `go test ./cmd/maestro/server -count=1`
  - `make lint-charts`

## Jira
- https://redhat.atlassian.net/browse/AROSLSRE-1951
- Parent: https://redhat.atlassian.net/browse/AROSLSRE-1844

## Checklist
- [x] Code changes are limited to liveness probe routing and regression coverage
- [x] Unit tests for new behavior added
- [x] Relevant tests/lint executed successfully

Co-authored with Red Hat Agentic SDLC AI Agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Maestro server liveness check to use the `/livez` endpoint.
  - Kept the readiness check on the `/healthcheck` endpoint for accurate service status reporting.

- **Tests**
  - Added coverage to verify that deployment health-check paths remain correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->