### PR TITLE
fix(db): index resource label containment queries (AROSLSRE-2076)

### DIFF
--- a/pkg/db/README.md
+++ b/pkg/db/README.md
@@ -58,6 +58,12 @@ If it is necessary to delete a record in a migration, be aware of a couple cavea
 
 See the [gorm documentation around deletions](http://gorm.io/docs/delete.html) for more information
 
+## Concurrent index migrations
+
+`Migrate` serializes migration history checks, DDL, and history writes across server replicas with a PostgreSQL session advisory lock on a dedicated connection. Migrations run without a surrounding transaction, so `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` can keep normal writes available.
+
+Lock acquisition uses polling. A blocking advisory-lock query can hold a snapshot needed by a concurrent expression-index build and cause a deadlock. An interrupted concurrent build can leave an invalid index, so its migration must handle that index before retrying.
+
 ## Migration tests
 
 In most cases, it shouldn't be necessary to create a test for a migration. However, if the migration is manipulating records and poses a significant risk of completely borking up important data, a test should be written.

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -2,9 +2,13 @@ package db
 
 import (
 	"context"
+	"database/sql/driver"
+	"errors"
+	"time"
 
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift-online/maestro/pkg/db/migrations"
@@ -13,7 +17,44 @@ import (
 // gormigrate is a wrapper for gorm's migration functions that adds schema versioning and rollback capabilities.
 // For help writing migration steps, see the gorm documentation on migrations: http://doc.gorm.io/database.html#migration
 
-func Migrate(g2 *gorm.DB) error {
+func Migrate(g2 *gorm.DB) (result error) {
+	sqlDB, err := g2.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(g2.Statement.Context)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Release the session lock even if the migration's context was cancelled.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_unlock(hashtext('maestro'), hashtext('migrations'))"); err != nil {
+			result = errors.Join(result, err)
+			// Never return a connection that may still hold the lock to the pool.
+			discardErr := conn.Raw(func(any) error { return driver.ErrBadConn })
+			if discardErr != nil && !errors.Is(discardErr, driver.ErrBadConn) {
+				result = errors.Join(result, discardErr)
+			}
+		}
+		result = errors.Join(result, conn.Close())
+	}()
+
+	// Serialize history checks, DDL and history writes across replica init containers.
+	// A pinned session lock allows concurrent index DDL outside a transaction.
+	g2 = g2.Session(&gorm.Session{NewDB: true, Context: g2.Statement.Context})
+	g2.Statement.ConnPool = conn
+	// A blocking lock query holds a snapshot that concurrent expression-index
+	// builds must wait for. Poll without keeping a query open to avoid a deadlock.
+	if err := wait.PollUntilContextCancel(g2.Statement.Context, time.Second, true, func(ctx context.Context) (bool, error) {
+		var acquired bool
+		err := g2.WithContext(ctx).Raw("SELECT pg_try_advisory_lock(hashtext('maestro'), hashtext('migrations'))").Scan(&acquired).Error
+		return acquired, err
+	}); err != nil {
+		return err
+	}
+
 	if err := migrations.CleanUpDirtyData(g2); err != nil {
 		return err
 	}

--- a/pkg/db/migrations/202609101040_add_resource_labels_index.go
+++ b/pkg/db/migrations/202609101040_add_resource_labels_index.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addResourceLabelsIndex() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202609101040",
+		Migrate: func(tx *gorm.DB) error {
+			// Concurrent builds can leave an invalid index if interrupted. Rebuild it
+			// on retry rather than skipping it with CREATE INDEX IF NOT EXISTS.
+			if err := tx.Exec("DROP INDEX CONCURRENTLY IF EXISTS idx_resources_payload_labels").Error; err != nil {
+				return err
+			}
+
+			// Gormigrate runs without a transaction, as required by CONCURRENTLY.
+			return tx.Exec(`CREATE INDEX CONCURRENTLY idx_resources_payload_labels
+				ON resources USING gin ((payload -> 'metadata' -> 'labels') jsonb_path_ops)`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Exec("DROP INDEX CONCURRENTLY IF EXISTS idx_resources_payload_labels").Error
+		},
+	}
+}

--- a/pkg/db/migrations/migration_structs.go
+++ b/pkg/db/migrations/migration_structs.go
@@ -35,6 +35,7 @@ var MigrationList = []*gormigrate.Migration{
 	addEventInstances(),
 	addLastHeartBeatAndReadyColumnInServerInstancesTable(),
 	alterEventInstances(),
+	addResourceLabelsIndex(),
 }
 
 // CleanUpDirtyData clean up the dirty data before migrating the tables.

--- a/test/integration/resource_labels_index_test.go
+++ b/test/integration/resource_labels_index_test.go
@@ -103,11 +103,19 @@ func TestResourceLabelsMigrationCancelledWhileWaiting(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	holder, err := sqlDB.Conn(h.Ctx)
 	Expect(err).NotTo(HaveOccurred())
-	defer holder.Close()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := holder.ExecContext(ctx, "SELECT pg_advisory_unlock(hashtext('maestro'), hashtext('migrations'))"); err != nil {
+			t.Errorf("release migration lock: %v", err)
+		}
+		if err := holder.Close(); err != nil {
+			t.Errorf("close migration lock connection: %v", err)
+		}
+	})
 
 	_, err = holder.ExecContext(h.Ctx, "SELECT pg_advisory_lock(hashtext('maestro'), hashtext('migrations'))")
 	Expect(err).NotTo(HaveOccurred())
-	defer holder.ExecContext(context.Background(), "SELECT pg_advisory_unlock(hashtext('maestro'), hashtext('migrations'))")
 
 	ctx, cancel := context.WithTimeout(h.Ctx, 100*time.Millisecond)
 	defer cancel()

--- a/test/integration/resource_labels_index_test.go
+++ b/test/integration/resource_labels_index_test.go
@@ -1,0 +1,119 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-online/maestro/pkg/db"
+	"github.com/openshift-online/maestro/pkg/db/migrations"
+	"github.com/openshift-online/maestro/test"
+)
+
+func TestResourceLabelsIndexMigration(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	conn := h.DBFactory.New(h.Ctx)
+	migrator := gormigrate.New(conn, gormigrate.DefaultOptions, migrations.MigrationList)
+	Expect(migrator.RollbackTo("202412181141")).To(Succeed())
+	_, err := h.CreateConsumer("consumer")
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(conn.Exec(`INSERT INTO resources
+		(id, name, version, source, consumer_name, deleted_at, payload)
+		SELECT i::text, 'resource-' || i, 1, 'source', 'consumer',
+			CASE WHEN i = 1 THEN now() END,
+			jsonb_build_object('metadata', jsonb_build_object('labels',
+				jsonb_build_object('cluster', 'cluster-' || (i % 256), 'type', 'bundle')),
+				'spec', repeat('x', 1024))
+		FROM generate_series(1, 1024) AS i`).Error).To(Succeed())
+
+	const query = `SELECT id FROM resources
+		WHERE source = 'source' AND consumer_name = 'consumer'
+			AND payload -> 'metadata' -> 'labels' @> '{"cluster":"cluster-1","type":"bundle"}'
+		ORDER BY id LIMIT 400`
+	var before []string
+	Expect(conn.Raw(query).Scan(&before).Error).To(Succeed())
+	Expect(before).To(Equal([]string{"1", "257", "513", "769"}))
+
+	// A failed concurrent build leaves an invalid index with the reserved name.
+	Expect(conn.Exec(`CREATE INDEX CONCURRENTLY idx_resources_payload_labels ON resources
+		(((payload -> 'metadata' -> 'labels' ->> 'cluster')::integer))`).Error).To(HaveOccurred())
+	var valid bool
+	Expect(conn.Raw(`SELECT indisvalid FROM pg_index
+		WHERE indexrelid = 'idx_resources_payload_labels'::regclass`).Scan(&valid).Error).To(Succeed())
+	Expect(valid).To(BeFalse())
+
+	// Replica init containers must not race the index DDL or migration history.
+	results := make(chan error, 2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			results <- db.Migrate(h.DBFactory.New(h.Ctx))
+		}()
+	}
+	close(start)
+	for i := 0; i < 2; i++ {
+		var migrationErr error
+		Eventually(results, "30s").Should(Receive(&migrationErr))
+		Expect(migrationErr).NotTo(HaveOccurred())
+	}
+	Expect(db.Migrate(conn)).To(Succeed())
+
+	Expect(conn.Raw(`SELECT indisvalid FROM pg_index
+		WHERE indexrelid = 'idx_resources_payload_labels'::regclass`).Scan(&valid).Error).To(Succeed())
+	Expect(valid).To(BeTrue())
+	var definition string
+	Expect(conn.Raw(`SELECT pg_get_indexdef('idx_resources_payload_labels'::regclass)`).
+		Scan(&definition).Error).To(Succeed())
+	Expect(definition).To(ContainSubstring("USING gin"))
+	Expect(definition).To(ContainSubstring("jsonb_path_ops"))
+
+	Expect(conn.Exec("ANALYZE resources").Error).To(Succeed())
+	var plan []string
+	Expect(conn.Raw("EXPLAIN " + query).Scan(&plan).Error).To(Succeed())
+	Expect(strings.Join(plan, "\n")).To(ContainSubstring("Bitmap Index Scan on idx_resources_payload_labels"))
+
+	var after []string
+	Expect(conn.Raw(query).Scan(&after).Error).To(Succeed())
+	Expect(after).To(Equal(before))
+
+	Expect(gormigrate.New(conn, gormigrate.DefaultOptions, migrations.MigrationList).
+		RollbackTo("202412181141")).To(Succeed())
+	var indexCount int64
+	Expect(conn.Raw(`SELECT count(*) FROM pg_indexes
+		WHERE schemaname = current_schema() AND indexname = 'idx_resources_payload_labels'`).
+		Scan(&indexCount).Error).To(Succeed())
+	Expect(indexCount).To(BeZero())
+	Expect(conn.Raw(query).Scan(&after).Error).To(Succeed())
+	Expect(after).To(Equal(before))
+
+	Expect(db.Migrate(conn)).To(Succeed())
+}
+
+func TestResourceLabelsMigrationCancelledWhileWaiting(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	conn := h.DBFactory.New(h.Ctx)
+	sqlDB, err := conn.DB()
+	Expect(err).NotTo(HaveOccurred())
+	holder, err := sqlDB.Conn(h.Ctx)
+	Expect(err).NotTo(HaveOccurred())
+	defer holder.Close()
+
+	_, err = holder.ExecContext(h.Ctx, "SELECT pg_advisory_lock(hashtext('maestro'), hashtext('migrations'))")
+	Expect(err).NotTo(HaveOccurred())
+	defer holder.ExecContext(context.Background(), "SELECT pg_advisory_unlock(hashtext('maestro'), hashtext('migrations'))")
+
+	ctx, cancel := context.WithTimeout(h.Ctx, 100*time.Millisecond)
+	defer cancel()
+	Expect(errors.Is(db.Migrate(conn.WithContext(ctx)), context.DeadlineExceeded)).To(BeTrue())
+
+	_, err = holder.ExecContext(h.Ctx, "SELECT pg_advisory_unlock(hashtext('maestro'), hashtext('migrations'))")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(db.Migrate(conn)).To(Succeed())
+}


### PR DESCRIPTION
## Description

Index resource-label containment queries with a GIN expression index on `(payload -> 'metadata' -> 'labels')`, using `jsonb_path_ops`.

A measured lookup returned two rows after filtering out 502, taking about 315 ms with warm buffers. The index lets PostgreSQL find matching labels directly without changing list or soft-delete behavior.

The migration builds and drops the index concurrently, handles an interrupted build, and serializes migration runners across replicas. Lock acquisition polls without holding an open query, avoiding a snapshot deadlock with concurrent expression-index builds.

Tracking: [AROSLSRE-2076](https://redhat.atlassian.net/browse/AROSLSRE-2076). This addresses query cost, not the full incident's root cause.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

PostgreSQL 17.10: the migration tests cover concurrent runners, an invalid index left by a failed build, repeated migration, cancellation while waiting, rollback and reapplication. A selective containment query uses the GIN index and returns the same records, including a soft-deleted resource.

```bash
go test ./pkg/db ./pkg/db/migrations ./pkg/client/cloudevents/grpcsource -count=1
MESSAGE_DRIVER_TYPE=grpc MAESTRO_ENV=testing go test ./test/integration \
  -run 'TestResourceLabels.*Migration|TestListSyncWorks' -count=3 -timeout=3m
```

The integration command needs the repository's local PostgreSQL configuration. The focused tests passed; the full suites were not run locally.

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a database index for resource labels to improve filtering and lookup performance.
  - Database migrations now coordinate safely across multiple application replicas.
  - Concurrent index changes keep normal database writes available.

- **Bug Fixes**
  - Interrupted index creation is detected and rebuilt automatically during a subsequent migration.
  - Migration attempts now stop cleanly when waiting exceeds the operation’s context deadline.

- **Documentation**
  - Added guidance on concurrent index migrations, retries, and handling interrupted index builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->